### PR TITLE
[#1] Client 관련 패키지 구조 설정 및 api 구현

### DIFF
--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/controller/ServiceRequestController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/controller/ServiceRequestController.java
@@ -4,10 +4,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jaega.homecare.domain.serviceRequest.dto.req.ConsumerServiceRequest;
+import jaega.homecare.domain.serviceRequest.dto.res.ConsumerServiceResponse;
+import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
 
 @Tag(name = "ServiceRequest", description = "ServiceRequest API")
 @RequestMapping("/api/consumer/request")
@@ -17,4 +20,14 @@ public interface ServiceRequestController {
     @ApiResponse(responseCode = "204", description = "수요자가 서비스 요청 성공")
     @PostMapping
     ResponseEntity<Void> createServiceRequest(@RequestBody ConsumerServiceRequest request);
+
+    @Operation(summary  = "수요자가 신청한 서비스 내역 조회 API", description = "수요자가 신청한 서비스를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "수요자가 신청한 서비스 내역 조회 성공")
+    @GetMapping
+    public ResponseEntity<List<ConsumerServiceResponse>> getConsumerServiceRequest(@RequestParam UUID userId);
+
+    @Operation(summary  = "수요자가 신청한 서비스 내역 조회 API (신청 서비스 상태 조건)", description = "수요자가 신청한 서비스를 신청한 서비스의 상태를 조건으로 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "수요자가 신청한 서비스 내역 신청 상태를 조건으로 조회 성공")
+    @GetMapping("/status")
+    public ResponseEntity<List<ConsumerServiceResponse>> getConsumerServiceRequestByStatus(@RequestParam UUID userId, ServiceRequestStatus status);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/controller/ServiceRequestController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/controller/ServiceRequestController.java
@@ -1,0 +1,20 @@
+package jaega.homecare.domain.serviceRequest.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jaega.homecare.domain.serviceRequest.dto.req.ConsumerServiceRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "ServiceRequest", description = "ServiceRequest API")
+@RequestMapping("/api/consumer/request")
+public interface ServiceRequestController {
+
+    @Operation(summary = "수요자 서비스 요청 API", description = "입력받은 정보로 수요자가 서비스를 요청합니다.")
+    @ApiResponse(responseCode = "204", description = "수요자가 서비스 요청 성공")
+    @PostMapping
+    ResponseEntity<Void> createServiceRequest(@RequestBody ConsumerServiceRequest request);
+}

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/controller/ServiceRequestControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/controller/ServiceRequestControllerImpl.java
@@ -1,13 +1,19 @@
 package jaega.homecare.domain.serviceRequest.controller;
 
 import jaega.homecare.domain.serviceRequest.dto.req.ConsumerServiceRequest;
+import jaega.homecare.domain.serviceRequest.dto.res.ConsumerServiceResponse;
+import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
 import jaega.homecare.domain.serviceRequest.service.command.ServiceRequestCommandService;
 import jaega.homecare.domain.serviceRequest.service.query.ServiceRequestQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
 
 @RequiredArgsConstructor
 @RestController
@@ -20,6 +26,18 @@ public class ServiceRequestControllerImpl implements ServiceRequestController{
     public ResponseEntity<Void> createServiceRequest(@RequestBody ConsumerServiceRequest request){
         serviceRequestCommandService.createServiceRequest(request);
         return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<List<ConsumerServiceResponse>> getConsumerServiceRequest(@RequestParam UUID userId){
+        List<ConsumerServiceResponse> response = serviceRequestQueryService.findConsumerRequests(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<List<ConsumerServiceResponse>> getConsumerServiceRequestByStatus(@RequestParam UUID userId, ServiceRequestStatus status){
+        List<ConsumerServiceResponse> response = serviceRequestQueryService.findConsumerRequestsByStatus(userId, status);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/controller/ServiceRequestControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/controller/ServiceRequestControllerImpl.java
@@ -1,0 +1,25 @@
+package jaega.homecare.domain.serviceRequest.controller;
+
+import jaega.homecare.domain.serviceRequest.dto.req.ConsumerServiceRequest;
+import jaega.homecare.domain.serviceRequest.service.command.ServiceRequestCommandService;
+import jaega.homecare.domain.serviceRequest.service.query.ServiceRequestQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/consumer/request")
+public class ServiceRequestControllerImpl implements ServiceRequestController{
+    private final ServiceRequestCommandService serviceRequestCommandService;
+    private final ServiceRequestQueryService serviceRequestQueryService;
+
+    @Override
+    public ResponseEntity<Void> createServiceRequest(@RequestBody ConsumerServiceRequest request){
+        serviceRequestCommandService.createServiceRequest(request);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/dto/req/ConsumerServiceRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/dto/req/ConsumerServiceRequest.java
@@ -1,6 +1,5 @@
 package jaega.homecare.domain.serviceRequest.dto.req;
 
-import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -11,7 +10,6 @@ public record ConsumerServiceRequest(
         LocalDateTime preferred_time_start,
         LocalDateTime preferred_time_end,
         String serviceType,
-        ServiceRequestStatus status,
         String personalityType,
         String requestedDays
 ) {

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/dto/req/ConsumerServiceRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/dto/req/ConsumerServiceRequest.java
@@ -1,0 +1,18 @@
+package jaega.homecare.domain.serviceRequest.dto.req;
+
+import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ConsumerServiceRequest(
+        UUID userId,
+        String location,
+        LocalDateTime preferred_time_start,
+        LocalDateTime preferred_time_end,
+        String serviceType,
+        ServiceRequestStatus status,
+        String personalityType,
+        String requestedDays
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/dto/res/ConsumerServiceResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/dto/res/ConsumerServiceResponse.java
@@ -1,0 +1,18 @@
+package jaega.homecare.domain.serviceRequest.dto.res;
+
+import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ConsumerServiceResponse(
+        UUID serviceRequestId,
+        String location,
+        LocalDateTime preferred_time_start,
+        LocalDateTime preferred_time_end,
+        String serviceType,
+        ServiceRequestStatus status,
+        String personalityType,
+        String requestedDays
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/entity/ServiceRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/entity/ServiceRequest.java
@@ -38,7 +38,7 @@ public class ServiceRequest {
 
     private String personalityType;
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "service_request_days", joinColumns = @JoinColumn(name = "service_request_id"))
     @Column(name = "requested_days")
     private Set<Integer> requestedDays; // ex : 1, 3, 5, ...

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/entity/ServiceRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/entity/ServiceRequest.java
@@ -1,0 +1,63 @@
+package jaega.homecare.domain.serviceRequest.entity;
+
+import jaega.homecare.domain.users.entity.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "serviceRequest")
+@NoArgsConstructor
+public class ServiceRequest {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private UUID serviceRequestId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "users_userId")
+    private User user;
+
+    private String location;
+
+    private LocalDateTime preferred_time_start;
+
+    private LocalDateTime preferred_time_end;
+
+    private String serviceType;
+
+    @Enumerated(EnumType.STRING)
+    private ServiceRequestStatus status;
+
+    private String personalityType;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "service_request_days", joinColumns = @JoinColumn(name = "service_request_id"))
+    @Column(name = "requested_days")
+    private Set<Integer> requestedDays; // ex : 1, 3, 5, ...
+
+    @Builder
+    public ServiceRequest(UUID serviceRequestId, User user, String location, LocalDateTime preferred_time_start, LocalDateTime preferred_time_end,
+                          String serviceType, ServiceRequestStatus status, String personalityType, Set<Integer> requestedDays){
+        this.location = location;
+        this.preferred_time_start = preferred_time_start;
+        this.preferred_time_end = preferred_time_end;
+        this.serviceType = serviceType;
+        this.personalityType = personalityType;
+        this.requestedDays = requestedDays;
+    }
+
+    public void setServiceRequest(UUID serviceRequestId, User user, ServiceRequestStatus status, Set<Integer> requestedDays){
+        this.serviceRequestId = serviceRequestId;
+        this.user = user;
+        this.status = status;
+        this.requestedDays = requestedDays;
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/entity/ServiceRequestStatus.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/entity/ServiceRequestStatus.java
@@ -1,0 +1,7 @@
+package jaega.homecare.domain.serviceRequest.entity;
+
+public enum ServiceRequestStatus {
+    PENDING,
+    ASSIGNED,
+    COMPLETED
+}

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/mapper/ServiceRequestMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/mapper/ServiceRequestMapper.java
@@ -1,9 +1,13 @@
 package jaega.homecare.domain.serviceRequest.mapper;
 
 import jaega.homecare.domain.serviceRequest.dto.req.ConsumerServiceRequest;
+import jaega.homecare.domain.serviceRequest.dto.res.ConsumerServiceResponse;
 import jaega.homecare.domain.serviceRequest.entity.ServiceRequest;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring")
 public interface ServiceRequestMapper {
@@ -18,4 +22,15 @@ public interface ServiceRequestMapper {
     @Mapping(target = "user", ignore = true)
     @Mapping(target = "status", ignore = true)
     ServiceRequest toEntity(ConsumerServiceRequest request);
+
+    @Mapping(target = "requestedDays", expression = "java(convertRequestedDays(request.getRequestedDays()))")
+    ConsumerServiceResponse toFindResponseDto(ServiceRequest request);
+
+    default String convertRequestedDays(Set<Integer> days) {
+        if (days == null || days.isEmpty()) return "";
+        return days.stream()
+                .sorted()
+                .map(String::valueOf)
+                .collect(Collectors.joining(", "));
+    }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/mapper/ServiceRequestMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/mapper/ServiceRequestMapper.java
@@ -1,0 +1,21 @@
+package jaega.homecare.domain.serviceRequest.mapper;
+
+import jaega.homecare.domain.serviceRequest.dto.req.ConsumerServiceRequest;
+import jaega.homecare.domain.serviceRequest.entity.ServiceRequest;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface ServiceRequestMapper {
+
+    @Mapping(target = "location", source = "request.location")
+    @Mapping(target = "preferred_time_start", source = "request.preferred_time_start")
+    @Mapping(target = "preferred_time_end", source = "request.preferred_time_end")
+    @Mapping(target = "serviceType", source = "request.serviceType")
+    @Mapping(target = "personalityType", source = "request.personalityType")
+    @Mapping(target = "requestedDays", ignore = true)
+    @Mapping(target = "serviceRequestId", ignore = true)
+    @Mapping(target = "user", ignore = true)
+    @Mapping(target = "status", ignore = true)
+    ServiceRequest toEntity(ConsumerServiceRequest request);
+}

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/repository/ServiceRequestRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/repository/ServiceRequestRepository.java
@@ -1,7 +1,18 @@
 package jaega.homecare.domain.serviceRequest.repository;
 
 import jaega.homecare.domain.serviceRequest.entity.ServiceRequest;
+import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
+import jaega.homecare.domain.users.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
 public interface ServiceRequestRepository extends JpaRepository<ServiceRequest, Long> {
+    Optional<ServiceRequest> findByServiceRequestId(UUID serviceRequestId);
+
+    List<ServiceRequest> findAllByUserAndStatus(User user, ServiceRequestStatus status);
+
+    List<ServiceRequest> findByUser(User user);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/repository/ServiceRequestRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/repository/ServiceRequestRepository.java
@@ -1,0 +1,7 @@
+package jaega.homecare.domain.serviceRequest.repository;
+
+import jaega.homecare.domain.serviceRequest.entity.ServiceRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ServiceRequestRepository extends JpaRepository<ServiceRequest, Long> {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/service/command/ServiceRequestCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/service/command/ServiceRequestCommandService.java
@@ -1,0 +1,48 @@
+package jaega.homecare.domain.serviceRequest.service.command;
+
+import jaega.homecare.domain.serviceRequest.dto.req.ConsumerServiceRequest;
+import jaega.homecare.domain.serviceRequest.entity.ServiceRequest;
+import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
+import jaega.homecare.domain.serviceRequest.mapper.ServiceRequestMapper;
+import jaega.homecare.domain.serviceRequest.repository.ServiceRequestRepository;
+import jaega.homecare.domain.users.entity.User;
+import jaega.homecare.domain.users.service.query.UserQueryService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ServiceRequestCommandService {
+
+    private final ServiceRequestRepository serviceRequestRepository;
+    private final UserQueryService userQueryService;
+    private final ServiceRequestMapper serviceRequestMapper;
+
+    @Transactional
+    public void createServiceRequest(ConsumerServiceRequest request){
+        User user = userQueryService.getUser(request.userId());
+
+        ServiceRequest serviceRequest = serviceRequestMapper.toEntity(request);
+        Set<Integer> requestedDaysSet = parseRequestedDays(request.requestedDays());
+
+        serviceRequest.setServiceRequest(UUID.randomUUID(), user, ServiceRequestStatus.PENDING, requestedDaysSet);
+        serviceRequestRepository.save(serviceRequest);
+    }
+
+    private Set<Integer> parseRequestedDays(String requestedDaysStr) {
+        if (requestedDaysStr == null || requestedDaysStr.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return Arrays.stream(requestedDaysStr.split(","))
+                .map(String::trim)
+                .map(Integer::parseInt)
+                .collect(Collectors.toSet());
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/service/query/ServiceRequestQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/service/query/ServiceRequestQueryService.java
@@ -1,0 +1,9 @@
+package jaega.homecare.domain.serviceRequest.service.query;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ServiceRequestQueryService {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/service/query/ServiceRequestQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/service/query/ServiceRequestQueryService.java
@@ -1,9 +1,66 @@
 package jaega.homecare.domain.serviceRequest.service.query;
 
+import jaega.homecare.domain.serviceRequest.dto.res.ConsumerServiceResponse;
+import jaega.homecare.domain.serviceRequest.entity.ServiceRequest;
+import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
+import jaega.homecare.domain.serviceRequest.mapper.ServiceRequestMapper;
+import jaega.homecare.domain.serviceRequest.repository.ServiceRequestRepository;
+import jaega.homecare.domain.users.entity.User;
+import jaega.homecare.domain.users.service.query.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ServiceRequestQueryService {
+
+    private final ServiceRequestRepository serviceRequestRepository;
+    private final UserQueryService userQueryService;
+    private final ServiceRequestMapper serviceRequestMapper;
+
+    public ServiceRequest getServiceRequest(UUID serviceRequestId){
+        return serviceRequestRepository.findByServiceRequestId(serviceRequestId)
+                .orElseThrow(() -> new NoSuchElementException(("서비스 요청 정보가 없습니다.")));
+    }
+
+
+    public List<ServiceRequest> getServiceRequestsByUser(User user){
+        List<ServiceRequest> requests = serviceRequestRepository.findByUser(user);
+        if (requests.isEmpty()) {
+            throw new NoSuchElementException("해당 유저의 서비스 요청 정보가 없습니다.");
+        }
+        return requests;
+    }
+
+    public List<ServiceRequest> getServiceRequestByUserAndStatus(User user, ServiceRequestStatus status){
+        List<ServiceRequest> requests = serviceRequestRepository.findAllByUserAndStatus(user, status);
+        if (requests.isEmpty()) {
+            throw new NoSuchElementException("해당 유저의 서비스 요청 정보가 없습니다.");
+        }
+        return requests;
+    }
+
+    public List<ConsumerServiceResponse> findConsumerRequests(UUID userId){
+        User user = userQueryService.getUser(userId);
+        List<ServiceRequest> serviceRequests = getServiceRequestsByUser(user);
+
+        return serviceRequests.stream()
+                .map(serviceRequestMapper::toFindResponseDto)
+                .collect(Collectors.toList());
+    }
+
+    public List<ConsumerServiceResponse> findConsumerRequestsByStatus(UUID userId, ServiceRequestStatus status){
+        User user = userQueryService.getUser(userId);
+        List<ServiceRequest> serviceRequests = getServiceRequestByUserAndStatus(user, status);
+
+        return serviceRequests.stream()
+                .map(serviceRequestMapper::toFindResponseDto)
+                .collect(Collectors.toList());
+    }
+
 }

--- a/homecare/src/main/java/jaega/homecare/domain/users/controller/UserController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/controller/UserController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/api/user")
 public interface UserController {
 
-    @Operation(summary = "수요자(고객) 회원가입 API", description = "입력받은 정보로 수요자의 회원가입을 진행합니다.")
+    @Operation(summary = "유저 기본 회원가입 API", description = "입력받은 정보로 유저의 기본 회원가입을 진행합니다.")
     @ApiResponse(responseCode = "204", description = "유저 생성 성공")
     @PostMapping("/register")
     ResponseEntity<Void> createConsumer(UserCreateRequest request);

--- a/homecare/src/main/java/jaega/homecare/domain/users/controller/UserController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/controller/UserController.java
@@ -1,11 +1,20 @@
 package jaega.homecare.domain.users.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jaega.homecare.domain.users.dto.req.UserCreateRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Tag(name = "User", description = "User API")
 @RequestMapping("/api/user")
 public interface UserController {
 
+    @Operation(summary = "수요자(고객) 회원가입 API", description = "입력받은 정보로 수요자의 회원가입을 진행합니다.")
+    @ApiResponse(responseCode = "204", description = "유저 생성 성공")
+    @PostMapping("/register")
+    ResponseEntity<Void> createConsumer(UserCreateRequest request);
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/users/controller/UserController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/controller/UserController.java
@@ -1,11 +1,17 @@
 package jaega.homecare.domain.users.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jaega.homecare.domain.users.dto.req.UserCreateRequest;
+import jaega.homecare.domain.users.dto.req.UserLoginRequest;
+import jaega.homecare.domain.users.dto.res.UserLoginResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Tag(name = "User", description = "User API")
@@ -15,6 +21,18 @@ public interface UserController {
     @Operation(summary = "유저 기본 회원가입 API", description = "입력받은 정보로 유저의 기본 회원가입을 진행합니다.")
     @ApiResponse(responseCode = "204", description = "유저 생성 성공")
     @PostMapping("/register")
-    ResponseEntity<Void> createConsumer(UserCreateRequest request);
+    ResponseEntity<Void> createConsumer(@RequestBody UserCreateRequest request);
+
+    @Operation(summary = "유저 로그인 API", description = "입력된 유저의 아이디, 비밀번호를 통해 로그인을 진행합니다.")
+    @ApiResponse(responseCode = "200", description = "유저 로그인 성공")
+    @ApiResponse(responseCode = "401", description = "로그인 실패 - 잘못된 인증 정보",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @PostMapping("/login")
+    ResponseEntity<UserLoginResponse> login(@RequestBody UserLoginRequest request);
+
+    @Operation(summary = "유저 로그아웃 API", description = "유저의 로그아웃을 진행합니다..")
+    @ApiResponse(responseCode = "200", description = "유저 로그아웃 성공")
+    @PostMapping("/logout")
+    ResponseEntity<Void> logout();
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/users/controller/UserController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/controller/UserController.java
@@ -1,0 +1,11 @@
+package jaega.homecare.domain.users.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "User", description = "User API")
+@RequestMapping("/api/user")
+public interface UserController {
+
+
+}

--- a/homecare/src/main/java/jaega/homecare/domain/users/controller/UserControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/controller/UserControllerImpl.java
@@ -20,7 +20,7 @@ public class UserControllerImpl implements UserController{
     private final UserQueryService userQueryService;
 
     @Override
-    public ResponseEntity<Void> createConsumer(UserCreateRequest request) {
+    public ResponseEntity<Void> createConsumer(@RequestBody UserCreateRequest request) {
         userCommandService.createConsumer(request);
         return ResponseEntity.noContent().build();
     }

--- a/homecare/src/main/java/jaega/homecare/domain/users/controller/UserControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/controller/UserControllerImpl.java
@@ -3,6 +3,7 @@ package jaega.homecare.domain.users.controller;
 import jaega.homecare.domain.users.dto.req.UserCreateRequest;
 import jaega.homecare.domain.users.dto.req.UserLoginRequest;
 import jaega.homecare.domain.users.dto.res.UserLoginResponse;
+import jaega.homecare.domain.users.entity.UserRole;
 import jaega.homecare.domain.users.service.command.UserCommandService;
 import jaega.homecare.domain.users.service.query.UserQueryService;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +22,7 @@ public class UserControllerImpl implements UserController{
 
     @Override
     public ResponseEntity<Void> createConsumer(@RequestBody UserCreateRequest request) {
-        userCommandService.createConsumer(request);
+        userCommandService.createUser(request, UserRole.ROLE_CONSUMER);
         return ResponseEntity.noContent().build();
     }
 

--- a/homecare/src/main/java/jaega/homecare/domain/users/controller/UserControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/controller/UserControllerImpl.java
@@ -1,6 +1,10 @@
 package jaega.homecare.domain.users.controller;
 
+import jaega.homecare.domain.users.dto.req.UserCreateRequest;
+import jaega.homecare.domain.users.service.command.UserCommandService;
+import jaega.homecare.domain.users.service.query.UserQueryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,4 +13,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/user")
 public class UserControllerImpl implements UserController{
 
+    private final UserCommandService userCommandService;
+    private final UserQueryService userQueryService;
+
+    @Override
+    public ResponseEntity<Void> createConsumer(UserCreateRequest request) {
+        userCommandService.createConsumer(request);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/users/controller/UserControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/controller/UserControllerImpl.java
@@ -1,0 +1,12 @@
+package jaega.homecare.domain.users.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/user")
+public class UserControllerImpl implements UserController{
+
+}

--- a/homecare/src/main/java/jaega/homecare/domain/users/controller/UserControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/controller/UserControllerImpl.java
@@ -1,10 +1,13 @@
 package jaega.homecare.domain.users.controller;
 
 import jaega.homecare.domain.users.dto.req.UserCreateRequest;
+import jaega.homecare.domain.users.dto.req.UserLoginRequest;
+import jaega.homecare.domain.users.dto.res.UserLoginResponse;
 import jaega.homecare.domain.users.service.command.UserCommandService;
 import jaega.homecare.domain.users.service.query.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,6 +22,18 @@ public class UserControllerImpl implements UserController{
     @Override
     public ResponseEntity<Void> createConsumer(UserCreateRequest request) {
         userCommandService.createConsumer(request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<UserLoginResponse> login(@RequestBody UserLoginRequest request) {
+        UserLoginResponse response = userCommandService.userLogin(request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<Void> logout() {
         return ResponseEntity.noContent().build();
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/users/dto/req/UserCreateRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/dto/req/UserCreateRequest.java
@@ -1,0 +1,9 @@
+package jaega.homecare.domain.users.dto.req;
+
+public record UserCreateRequest(
+        String name,
+        String email,
+        String password,
+        String phone
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/users/dto/req/UserLoginRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/dto/req/UserLoginRequest.java
@@ -1,0 +1,7 @@
+package jaega.homecare.domain.users.dto.req;
+
+public record UserLoginRequest(
+        String email,
+        String password
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/users/dto/res/UserLoginResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/dto/res/UserLoginResponse.java
@@ -1,0 +1,8 @@
+package jaega.homecare.domain.users.dto.res;
+
+import java.util.UUID;
+
+public record UserLoginResponse (
+        UUID userId
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/users/entity/User.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/entity/User.java
@@ -34,4 +34,18 @@ public class User {
 
     private LocalDateTime createdAt;
 
+    @Builder
+    public User(String name, String email, String password, String phone,
+                UUID userId, UserRole userRole, LocalDateTime createdAt){
+        this.name = name;
+        this.email = email;
+        this.password = password;
+        this.phone = phone;
+    }
+
+    public void setUser(UUID userId, UserRole userRole, LocalDateTime createdAt){
+        this.userId = userId;
+        this.userRole = userRole;
+        this.createdAt = createdAt;
+    }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/users/entity/User.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/entity/User.java
@@ -1,0 +1,37 @@
+package jaega.homecare.domain.users.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "users")
+@NoArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private UUID userId;
+
+    @Column
+    private String name;
+
+    @Column
+    private String email;
+
+    @Column
+    private String password;
+
+    @Column
+    private String phone;
+
+    @Enumerated(EnumType.STRING)
+    private UserRole userRole;
+
+    private LocalDateTime createdAt;
+
+}

--- a/homecare/src/main/java/jaega/homecare/domain/users/entity/User.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/entity/User.java
@@ -17,16 +17,12 @@ public class User {
 
     private UUID userId;
 
-    @Column
     private String name;
 
-    @Column
     private String email;
 
-    @Column
     private String password;
 
-    @Column
     private String phone;
 
     @Enumerated(EnumType.STRING)

--- a/homecare/src/main/java/jaega/homecare/domain/users/entity/UserRole.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/entity/UserRole.java
@@ -1,6 +1,7 @@
 package jaega.homecare.domain.users.entity;
 
 public enum UserRole {
+    ROLE_CONSUMER,
     ROLE_CAREGIVER,
     ROLE_CENTER,
     ROLE_ADMIN

--- a/homecare/src/main/java/jaega/homecare/domain/users/entity/UserRole.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/entity/UserRole.java
@@ -1,0 +1,7 @@
+package jaega.homecare.domain.users.entity;
+
+public enum UserRole {
+    ROLE_CAREGIVER,
+    ROLE_CENTER,
+    ROLE_ADMIN
+}

--- a/homecare/src/main/java/jaega/homecare/domain/users/mapper/UserMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/mapper/UserMapper.java
@@ -1,19 +1,24 @@
 package jaega.homecare.domain.users.mapper;
 
 import jaega.homecare.domain.users.dto.req.UserCreateRequest;
+import jaega.homecare.domain.users.dto.res.UserLoginResponse;
 import jaega.homecare.domain.users.entity.User;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+
+import java.util.UUID;
 
 @Mapper(componentModel = "spring")
 public interface UserMapper {
 
     @Mapping(target = "name", source = "request.name")
     @Mapping(target = "email", source = "request.email")
-    @Mapping(target = "password", source = "request.password")
+    @Mapping(target = "password", source = "password")
     @Mapping(target = "phone", source = "request.phone")
     @Mapping(target = "userId", ignore = true)
     @Mapping(target = "userRole", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
-    User toEntity(UserCreateRequest request);
+    User toEntity(UserCreateRequest request, String password);
+
+    UserLoginResponse toLoginResponse(UUID userId);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/users/mapper/UserMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/mapper/UserMapper.java
@@ -1,0 +1,19 @@
+package jaega.homecare.domain.users.mapper;
+
+import jaega.homecare.domain.users.dto.req.UserCreateRequest;
+import jaega.homecare.domain.users.entity.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface UserMapper {
+
+    @Mapping(target = "name", source = "request.name")
+    @Mapping(target = "email", source = "request.email")
+    @Mapping(target = "password", source = "request.password")
+    @Mapping(target = "phone", source = "request.phone")
+    @Mapping(target = "userId", ignore = true)
+    @Mapping(target = "userRole", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    User toEntity(UserCreateRequest request);
+}

--- a/homecare/src/main/java/jaega/homecare/domain/users/repository/UserRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package jaega.homecare.domain.users.repository;
+
+import jaega.homecare.domain.users.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/users/repository/UserRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/repository/UserRepository.java
@@ -4,4 +4,7 @@ import jaega.homecare.domain.users.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    Boolean existsByEmail(String email);
+
+    User findByEmail(String email);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/users/repository/UserRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/repository/UserRepository.java
@@ -3,8 +3,13 @@ package jaega.homecare.domain.users.repository;
 import jaega.homecare.domain.users.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 public interface UserRepository extends JpaRepository<User, Long> {
     Boolean existsByEmail(String email);
+
+    Optional<User> findByUserId(UUID userId);
 
     User findByEmail(String email);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/users/service/command/UserCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/service/command/UserCommandService.java
@@ -1,0 +1,11 @@
+package jaega.homecare.domain.users.service.command;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class UserCommandService {
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/users/service/command/UserCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/service/command/UserCommandService.java
@@ -1,11 +1,31 @@
 package jaega.homecare.domain.users.service.command;
 
+import jaega.homecare.domain.users.dto.req.UserCreateRequest;
+import jaega.homecare.domain.users.entity.User;
+import jaega.homecare.domain.users.entity.UserRole;
+import jaega.homecare.domain.users.mapper.UserMapper;
+import jaega.homecare.domain.users.repository.UserRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class UserCommandService {
+    private final UserRepository userRepository;
+    private final UserMapper userMapper;
+
+    @Transactional
+    public void createConsumer(UserCreateRequest request){
+        if (userRepository.existsByEmail(request.email())) {
+            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+        }
+
+        User user = userMapper.toEntity(request);
+        user.setUser(UUID.randomUUID(), UserRole.ROLE_CAREGIVER, LocalDateTime.now());
+        userRepository.save(user);
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/users/service/command/UserCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/service/command/UserCommandService.java
@@ -7,13 +7,11 @@ import jaega.homecare.domain.users.entity.User;
 import jaega.homecare.domain.users.entity.UserRole;
 import jaega.homecare.domain.users.mapper.UserMapper;
 import jaega.homecare.domain.users.repository.UserRepository;
-import jaega.homecare.domain.users.service.query.UserQueryService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -28,7 +26,7 @@ public class UserCommandService {
     @Transactional
     public void createConsumer(UserCreateRequest request){
         if (userRepository.existsByEmail(request.email())) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다.");
+            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
         }
 
         String password = passwordEncoder.encode(request.password());
@@ -42,7 +40,7 @@ public class UserCommandService {
     public UserLoginResponse userLogin(UserLoginRequest request){
         User user = userRepository.findByEmail(request.email());
         if (user == null || !passwordEncoder.matches(request.password(), user.getPassword())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "로그인에 실패했습니다.");
+            throw new BadCredentialsException("로그인에 실패했습니다.");
         }
 
         return userMapper.toLoginResponse(user.getUserId());

--- a/homecare/src/main/java/jaega/homecare/domain/users/service/command/UserCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/service/command/UserCommandService.java
@@ -1,13 +1,19 @@
 package jaega.homecare.domain.users.service.command;
 
 import jaega.homecare.domain.users.dto.req.UserCreateRequest;
+import jaega.homecare.domain.users.dto.req.UserLoginRequest;
+import jaega.homecare.domain.users.dto.res.UserLoginResponse;
 import jaega.homecare.domain.users.entity.User;
 import jaega.homecare.domain.users.entity.UserRole;
 import jaega.homecare.domain.users.mapper.UserMapper;
 import jaega.homecare.domain.users.repository.UserRepository;
+import jaega.homecare.domain.users.service.query.UserQueryService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -17,6 +23,7 @@ import java.util.UUID;
 public class UserCommandService {
     private final UserRepository userRepository;
     private final UserMapper userMapper;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public void createConsumer(UserCreateRequest request){
@@ -24,8 +31,20 @@ public class UserCommandService {
             throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
         }
 
-        User user = userMapper.toEntity(request);
+        String password = passwordEncoder.encode(request.password());
+
+        User user = userMapper.toEntity(request, password);
         user.setUser(UUID.randomUUID(), UserRole.ROLE_CAREGIVER, LocalDateTime.now());
         userRepository.save(user);
+    }
+
+    @Transactional
+    public UserLoginResponse userLogin(UserLoginRequest request){
+        User user = userRepository.findByEmail(request.email());
+        if (user == null || !passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "로그인에 실패했습니다.");
+        }
+
+        return userMapper.toLoginResponse(user.getUserId());
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/users/service/command/UserCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/service/command/UserCommandService.java
@@ -24,7 +24,7 @@ public class UserCommandService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public void createConsumer(UserCreateRequest request){
+    public void createUser(UserCreateRequest request, UserRole role){
         if (userRepository.existsByEmail(request.email())) {
             throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
         }
@@ -32,7 +32,7 @@ public class UserCommandService {
         String password = passwordEncoder.encode(request.password());
 
         User user = userMapper.toEntity(request, password);
-        user.setUser(UUID.randomUUID(), UserRole.ROLE_CAREGIVER, LocalDateTime.now());
+        user.setUser(UUID.randomUUID(), role, LocalDateTime.now());
         userRepository.save(user);
     }
 

--- a/homecare/src/main/java/jaega/homecare/domain/users/service/command/UserCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/service/command/UserCommandService.java
@@ -28,7 +28,7 @@ public class UserCommandService {
     @Transactional
     public void createConsumer(UserCreateRequest request){
         if (userRepository.existsByEmail(request.email())) {
-            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다.");
         }
 
         String password = passwordEncoder.encode(request.password());

--- a/homecare/src/main/java/jaega/homecare/domain/users/service/query/UserQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/service/query/UserQueryService.java
@@ -1,9 +1,21 @@
 package jaega.homecare.domain.users.service.query;
 
+import jaega.homecare.domain.users.entity.User;
+import jaega.homecare.domain.users.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class UserQueryService {
+    private final UserRepository userRepository;
+
+    public User getUser(UUID userId){
+        return userRepository.findByUserId(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."));
+    }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/users/service/query/UserQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/service/query/UserQueryService.java
@@ -1,0 +1,9 @@
+package jaega.homecare.domain.users.service.query;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserQueryService {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/users/service/query/UserQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/service/query/UserQueryService.java
@@ -3,10 +3,9 @@ package jaega.homecare.domain.users.service.query;
 import jaega.homecare.domain.users.entity.User;
 import jaega.homecare.domain.users.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
 
+import java.util.NoSuchElementException;
 import java.util.UUID;
 
 @Service
@@ -16,6 +15,6 @@ public class UserQueryService {
 
     public User getUser(UUID userId){
         return userRepository.findByUserId(userId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 유저입니다."));
     }
 }

--- a/homecare/src/main/java/jaega/homecare/global/config/SecurityConfig.java
+++ b/homecare/src/main/java/jaega/homecare/global/config/SecurityConfig.java
@@ -8,6 +8,8 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -34,5 +36,10 @@ public class SecurityConfig {
                 .httpBasic(httpBasic -> httpBasic.disable());
 
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/homecare/src/main/resources/application.yml
+++ b/homecare/src/main/resources/application.yml
@@ -1,5 +1,4 @@
 spring:
-  applicaton:
   application:
     name: homecare
 

--- a/homecare/src/main/resources/application.yml
+++ b/homecare/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 spring:
   applicaton:
+  application:
     name: homecare
 
   config:


### PR DESCRIPTION
## #️⃣연관된 이슈

>- close #1 

## 📝작업 내용

- Client 관련 패키지 구조 설정
- 회원가입, 로그인/아웃과 같은 공통 api 구현
- 요양 서비스 신청, 조회 api 구현

### 스크린샷 (선택)

<br>

## 💬리뷰 요구사항(선택)

### 1. 회원가입 api에서 User는 수요자와 공급자가 공통으로 사용되는 정보를 포함하여, 공통 모듈로 분리했습니다.
- 수요자, 공급자 모두 기본적으로 User 도메인의 공통 정보가 필요하여 회원가입 로직만을 하나의 공통 모듈로 구현했습니다.

### 2. 로그인/아웃은 비밀번호 검증만 구현이 되어있는 상태입니다.
- 로그인/아웃은 Jwt 인증 로직이 구현될 시 ( 구름톤? 혹은 해커톤 이후?)에 빈 공간에 넣을 예정입니다.
- 로그아웃은 Jwt 인증 과정에 기능을 부여하므로 말 그대로 api만 구현되어있습니다.

### 3. 최대한 각 역할마다 책임을 분리하여 구현했습니다.
- 특히 요양 서비스(ServiceRequest)의 경우 유저 ID와 상태를 조건으로 조회하는 api는 활용처가 많을 것 같아 컴포넌트화하여 구성했습니다.