### PR TITLE
[#4] User api 분리 및 클라이언트 요구사항 반영

### DIFF
--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/controller/ServiceRequestController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/controller/ServiceRequestController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
-@Tag(name = "ServiceRequest", description = "ServiceRequest API")
+@Tag(name = "ServiceRequest", description = "Consumer의 서비스 신청 API")
 @RequestMapping("/api/consumer/request")
 public interface ServiceRequestController {
 

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/dto/req/ConsumerServiceRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/dto/req/ConsumerServiceRequest.java
@@ -11,6 +11,7 @@ public record ConsumerServiceRequest(
         LocalDateTime preferred_time_end,
         String serviceType,
         String personalityType,
-        String requestedDays
+        String requestedDays,
+        String additionalInformation
 ) {
 }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/entity/ServiceRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/entity/ServiceRequest.java
@@ -43,15 +43,18 @@ public class ServiceRequest {
     @Column(name = "requested_days")
     private Set<Integer> requestedDays; // ex : 1, 3, 5, ...
 
+    private String additionalInformation;
+
     @Builder
     public ServiceRequest(UUID serviceRequestId, User user, String location, LocalDateTime preferred_time_start, LocalDateTime preferred_time_end,
-                          String serviceType, ServiceRequestStatus status, String personalityType, Set<Integer> requestedDays){
+                          String serviceType, ServiceRequestStatus status, String personalityType, Set<Integer> requestedDays, String additionalInformation){
         this.location = location;
         this.preferred_time_start = preferred_time_start;
         this.preferred_time_end = preferred_time_end;
         this.serviceType = serviceType;
         this.personalityType = personalityType;
         this.requestedDays = requestedDays;
+        this.additionalInformation = additionalInformation;
     }
 
     public void setServiceRequest(UUID serviceRequestId, User user, ServiceRequestStatus status, Set<Integer> requestedDays){

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/mapper/ServiceRequestMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/mapper/ServiceRequestMapper.java
@@ -17,6 +17,7 @@ public interface ServiceRequestMapper {
     @Mapping(target = "preferred_time_end", source = "request.preferred_time_end")
     @Mapping(target = "serviceType", source = "request.serviceType")
     @Mapping(target = "personalityType", source = "request.personalityType")
+    @Mapping(target = "additionalInformation", source = "request.additionalInformation")
     @Mapping(target = "requestedDays", ignore = true)
     @Mapping(target = "serviceRequestId", ignore = true)
     @Mapping(target = "user", ignore = true)

--- a/homecare/src/main/java/jaega/homecare/domain/users/controller/ConsumerController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/controller/ConsumerController.java
@@ -1,0 +1,20 @@
+package jaega.homecare.domain.users.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jaega.homecare.domain.users.dto.req.ConsumerCreateRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "User_Consumer", description = "유저(consumer) API")
+@RequestMapping("/api/consumer")
+public interface ConsumerController {
+
+    @Operation(summary = "수요자 회원가입 API", description = "입력받은 정보로 수요자의 회원가입을 진행합니다.")
+    @ApiResponse(responseCode = "204", description = "수요자 회원가입 성공")
+    @PostMapping("/register")
+    ResponseEntity<Void> createConsumer(@RequestBody ConsumerCreateRequest request);
+}

--- a/homecare/src/main/java/jaega/homecare/domain/users/controller/ConsumerControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/controller/ConsumerControllerImpl.java
@@ -1,0 +1,25 @@
+package jaega.homecare.domain.users.controller;
+
+import jaega.homecare.domain.users.dto.req.ConsumerCreateRequest;
+import jaega.homecare.domain.users.entity.UserRole;
+import jaega.homecare.domain.users.service.command.ConsumerCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/consumer")
+public class ConsumerControllerImpl implements ConsumerController {
+
+    private final ConsumerCommandService consumerCommandService;
+
+    @Override
+    public ResponseEntity<Void> createConsumer(@RequestBody ConsumerCreateRequest request) {
+        consumerCommandService.createUser(request, UserRole.ROLE_CONSUMER);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/homecare/src/main/java/jaega/homecare/domain/users/controller/UserController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/controller/UserController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jaega.homecare.domain.users.dto.req.UserCreateRequest;
 import jaega.homecare.domain.users.dto.req.UserLoginRequest;
 import jaega.homecare.domain.users.dto.res.UserLoginResponse;
 import org.springframework.http.ResponseEntity;
@@ -14,14 +13,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@Tag(name = "User", description = "User API")
+@Tag(name = "User", description = "유저(공통) API")
 @RequestMapping("/api/user")
 public interface UserController {
-
-    @Operation(summary = "유저 기본 회원가입 API", description = "입력받은 정보로 유저의 기본 회원가입을 진행합니다.")
-    @ApiResponse(responseCode = "204", description = "유저 생성 성공")
-    @PostMapping("/register")
-    ResponseEntity<Void> createConsumer(@RequestBody UserCreateRequest request);
 
     @Operation(summary = "유저 로그인 API", description = "입력된 유저의 아이디, 비밀번호를 통해 로그인을 진행합니다.")
     @ApiResponse(responseCode = "200", description = "유저 로그인 성공")

--- a/homecare/src/main/java/jaega/homecare/domain/users/controller/UserControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/controller/UserControllerImpl.java
@@ -1,9 +1,7 @@
 package jaega.homecare.domain.users.controller;
 
-import jaega.homecare.domain.users.dto.req.UserCreateRequest;
 import jaega.homecare.domain.users.dto.req.UserLoginRequest;
 import jaega.homecare.domain.users.dto.res.UserLoginResponse;
-import jaega.homecare.domain.users.entity.UserRole;
 import jaega.homecare.domain.users.service.command.UserCommandService;
 import jaega.homecare.domain.users.service.query.UserQueryService;
 import lombok.RequiredArgsConstructor;
@@ -19,12 +17,6 @@ public class UserControllerImpl implements UserController{
 
     private final UserCommandService userCommandService;
     private final UserQueryService userQueryService;
-
-    @Override
-    public ResponseEntity<Void> createConsumer(@RequestBody UserCreateRequest request) {
-        userCommandService.createUser(request, UserRole.ROLE_CONSUMER);
-        return ResponseEntity.noContent().build();
-    }
 
     @Override
     public ResponseEntity<UserLoginResponse> login(@RequestBody UserLoginRequest request) {

--- a/homecare/src/main/java/jaega/homecare/domain/users/dto/req/ConsumerCreateRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/dto/req/ConsumerCreateRequest.java
@@ -1,6 +1,6 @@
 package jaega.homecare.domain.users.dto.req;
 
-public record UserCreateRequest(
+public record ConsumerCreateRequest(
         String name,
         String email,
         String password,

--- a/homecare/src/main/java/jaega/homecare/domain/users/dto/req/ConsumerCreateRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/dto/req/ConsumerCreateRequest.java
@@ -1,9 +1,12 @@
 package jaega.homecare.domain.users.dto.req;
 
+import java.time.LocalDate;
+
 public record ConsumerCreateRequest(
         String name,
         String email,
         String password,
-        String phone
+        String phone,
+        LocalDate birthDate
 ) {
 }

--- a/homecare/src/main/java/jaega/homecare/domain/users/entity/User.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/entity/User.java
@@ -3,6 +3,7 @@ package jaega.homecare.domain.users.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -25,18 +26,21 @@ public class User {
 
     private String phone;
 
+    private LocalDate birthDate;
+
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
 
     private LocalDateTime createdAt;
 
     @Builder
-    public User(String name, String email, String password, String phone,
+    public User(String name, String email, String password, String phone, LocalDate birthDate,
                 UUID userId, UserRole userRole, LocalDateTime createdAt){
         this.name = name;
         this.email = email;
         this.password = password;
         this.phone = phone;
+        this.birthDate = birthDate;
     }
 
     public void setUser(UUID userId, UserRole userRole, LocalDateTime createdAt){

--- a/homecare/src/main/java/jaega/homecare/domain/users/mapper/ConsumerMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/mapper/ConsumerMapper.java
@@ -12,6 +12,7 @@ public interface ConsumerMapper {
     @Mapping(target = "email", source = "request.email")
     @Mapping(target = "password", source = "password")
     @Mapping(target = "phone", source = "request.phone")
+    @Mapping(target = "birthDate", source = "request.birthDate")
     @Mapping(target = "userId", ignore = true)
     @Mapping(target = "userRole", ignore = true)
     @Mapping(target = "createdAt", ignore = true)

--- a/homecare/src/main/java/jaega/homecare/domain/users/mapper/ConsumerMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/mapper/ConsumerMapper.java
@@ -1,0 +1,19 @@
+package jaega.homecare.domain.users.mapper;
+
+import jaega.homecare.domain.users.dto.req.ConsumerCreateRequest;
+import jaega.homecare.domain.users.entity.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface ConsumerMapper {
+
+    @Mapping(target = "name", source = "request.name")
+    @Mapping(target = "email", source = "request.email")
+    @Mapping(target = "password", source = "password")
+    @Mapping(target = "phone", source = "request.phone")
+    @Mapping(target = "userId", ignore = true)
+    @Mapping(target = "userRole", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    User toEntity(ConsumerCreateRequest request, String password);
+}

--- a/homecare/src/main/java/jaega/homecare/domain/users/mapper/UserMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/mapper/UserMapper.java
@@ -1,24 +1,12 @@
 package jaega.homecare.domain.users.mapper;
 
-import jaega.homecare.domain.users.dto.req.UserCreateRequest;
 import jaega.homecare.domain.users.dto.res.UserLoginResponse;
-import jaega.homecare.domain.users.entity.User;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 
 import java.util.UUID;
 
 @Mapper(componentModel = "spring")
 public interface UserMapper {
-
-    @Mapping(target = "name", source = "request.name")
-    @Mapping(target = "email", source = "request.email")
-    @Mapping(target = "password", source = "password")
-    @Mapping(target = "phone", source = "request.phone")
-    @Mapping(target = "userId", ignore = true)
-    @Mapping(target = "userRole", ignore = true)
-    @Mapping(target = "createdAt", ignore = true)
-    User toEntity(UserCreateRequest request, String password);
 
     UserLoginResponse toLoginResponse(UUID userId);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/users/service/command/ConsumerCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/service/command/ConsumerCommandService.java
@@ -1,0 +1,36 @@
+package jaega.homecare.domain.users.service.command;
+
+import jaega.homecare.domain.users.dto.req.ConsumerCreateRequest;
+import jaega.homecare.domain.users.entity.User;
+import jaega.homecare.domain.users.entity.UserRole;
+import jaega.homecare.domain.users.mapper.ConsumerMapper;
+import jaega.homecare.domain.users.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ConsumerCommandService {
+
+    private final UserRepository userRepository;
+    private final ConsumerMapper consumerMapper;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void createUser(ConsumerCreateRequest request, UserRole role){
+        if (userRepository.existsByEmail(request.email())) {
+            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+        }
+
+        String password = passwordEncoder.encode(request.password());
+
+        User user = consumerMapper.toEntity(request, password);
+        user.setUser(UUID.randomUUID(), role, LocalDateTime.now());
+        userRepository.save(user);
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/users/service/command/UserCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/service/command/UserCommandService.java
@@ -1,10 +1,8 @@
 package jaega.homecare.domain.users.service.command;
 
-import jaega.homecare.domain.users.dto.req.UserCreateRequest;
 import jaega.homecare.domain.users.dto.req.UserLoginRequest;
 import jaega.homecare.domain.users.dto.res.UserLoginResponse;
 import jaega.homecare.domain.users.entity.User;
-import jaega.homecare.domain.users.entity.UserRole;
 import jaega.homecare.domain.users.mapper.UserMapper;
 import jaega.homecare.domain.users.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -13,28 +11,12 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
-import java.util.UUID;
-
 @Service
 @RequiredArgsConstructor
 public class UserCommandService {
     private final UserRepository userRepository;
     private final UserMapper userMapper;
     private final PasswordEncoder passwordEncoder;
-
-    @Transactional
-    public void createUser(UserCreateRequest request, UserRole role){
-        if (userRepository.existsByEmail(request.email())) {
-            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
-        }
-
-        String password = passwordEncoder.encode(request.password());
-
-        User user = userMapper.toEntity(request, password);
-        user.setUser(UUID.randomUUID(), role, LocalDateTime.now());
-        userRepository.save(user);
-    }
 
     @Transactional
     public UserLoginResponse userLogin(UserLoginRequest request){

--- a/homecare/src/main/java/jaega/homecare/domain/users/service/query/ConsumerQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/service/query/ConsumerQueryService.java
@@ -1,0 +1,9 @@
+package jaega.homecare.domain.users.service.query;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ConsumerQueryService {
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #4  

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 1. User의 client api 분리
- User의 client api를 권한(consumer, caregiver, center, ...)를 기준으로 controller, service, mapper를 분리했습니다.

### 2. 클라이언트의 요구사항에 맞게 api 및 db 구조 변경
- 클라이언트의 요구사항과 설계에 맞게 consumer의 서비스 요청 테이블에 '추가 정보' 속성을 추가했습니다.
- 유저의 기본 회원가입 정보에는 '생년월일' 속성을 추가했습니다.

### 스크린샷 (선택)

<br>

## 💬리뷰 요구사항(선택)

