### PR TITLE
[#3] Center, Caregiver 패키지 세팅 및 보호사 등록/조회 API 구현

### DIFF
--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
@@ -1,0 +1,77 @@
+package jaega.homecare.domain.caregiver.entity;
+
+import jaega.homecare.domain.center.entity.Center;
+import jaega.homecare.domain.users.entity.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "caregiver")
+@NoArgsConstructor
+public class Caregiver {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(name = "caregiver_id", unique = true)
+    private UUID caregiverId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "center_id")
+    private Center center;
+
+    // 근무 시작 시간
+    @Column(name = "available_start_time")
+    private LocalTime availableStartTime;
+
+    // 근무 종료 시간
+    @Column(name = "available_end_time")
+    private LocalTime availableEndTime;
+
+    @Column(name = "address")
+    private String address;
+
+    // 서비스 유형 (다중 선택 가능)
+    @ElementCollection(targetClass = ServiceType.class, fetch = FetchType.LAZY)
+    @CollectionTable(name = "service_type", joinColumns = @JoinColumn(name = "caregiver_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "service_type")
+    private Set<ServiceType> serviceTypes = new HashSet<>();
+
+    // 휴무일 (다중 선택 가능)
+    @ElementCollection(targetClass = DayOfWeek.class, fetch = FetchType.LAZY)
+    @CollectionTable(name = "days_off", joinColumns = @JoinColumn(name = "caregiver_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "day_of_week")
+    private Set<DayOfWeek> daysOff = new HashSet<>();
+
+    @Builder
+    public Caregiver(UUID caregiverId, User user, Center center, LocalTime availableStartTime, LocalTime availableEndTime, String address, Set<ServiceType> serviceTypes, Set<DayOfWeek> daysOff) {
+        this.caregiverId = caregiverId;
+        this.user = user;
+        this.center = center;
+        this.availableStartTime = availableStartTime;
+        this.availableEndTime = availableEndTime;
+        this.address = address;
+        this.serviceTypes = serviceTypes;
+        this.daysOff = daysOff;
+    }
+
+    public void initializeCaregiver(UUID uuid) {
+        this.caregiverId = uuid;
+    }
+
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/ServiceType.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/ServiceType.java
@@ -1,0 +1,9 @@
+package jaega.homecare.domain.caregiver.entity;
+
+public enum ServiceType {
+    VISITING_CARE,      // 방문 요양
+    VISITING_BATH,      // 방문 목욕
+    VISITING_NURSING,   // 방문 간호
+    DAY_NIGHT_CARE,     // 주야간 보호
+    RESPITE_CARE        // 단기 보호
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/mapper/CaregiverMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/mapper/CaregiverMapper.java
@@ -1,0 +1,32 @@
+package jaega.homecare.domain.caregiver.mapper;
+
+import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.domain.center.dto.req.CreateCaregiverRequest;
+import jaega.homecare.domain.center.entity.Center;
+import jaega.homecare.domain.users.entity.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface CaregiverMapper {
+
+    @Mapping(target = "name", source = "request.name")
+    @Mapping(target = "email", source = "request.email")
+    @Mapping(target = "password", source = "password")
+    @Mapping(target = "phone", source = "request.phone")
+    @Mapping(target = "birthDate", source = "request.birthDate")
+    @Mapping(target = "userId", ignore = true)
+    @Mapping(target = "userRole", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    User toUserEntity(CreateCaregiverRequest request, String password);
+
+    @Mapping(target = "address", source = "address")
+    @Mapping(target = "user", source = "user")
+    @Mapping(target = "center", source = "center")
+    @Mapping(target = "caregiverId", ignore = true)
+    @Mapping(target = "availableStartTime", ignore = true)
+    @Mapping(target = "availableEndTime", ignore = true)
+    @Mapping(target = "serviceTypes", ignore = true)
+    @Mapping(target = "daysOff", ignore = true)
+    Caregiver toEntity(String address, User user, Center center);
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverQueryRepository.java
@@ -1,0 +1,40 @@
+package jaega.homecare.domain.caregiver.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.domain.caregiver.entity.QCaregiver;
+import jaega.homecare.domain.center.dto.res.GetCaregiverResponse;
+import jaega.homecare.domain.users.entity.QUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class CaregiverQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public List<GetCaregiverResponse> findAllByCenterId(UUID centerId) {
+        QCaregiver caregiver = QCaregiver.caregiver;
+        QUser user = QUser.user;
+
+        List<Caregiver> caregivers = queryFactory
+                .selectFrom(caregiver).distinct()
+                .join(caregiver.user, user).fetchJoin()
+                .leftJoin(caregiver.serviceTypes).fetchJoin()
+                .where(caregiver.center.centerId.eq(centerId))
+                .fetch();
+
+        // 각 Caregiver -> Dto
+        return caregivers.stream()
+                .map(c -> new GetCaregiverResponse(
+                        c.getCaregiverId(),
+                        c.getUser().getName(),
+                        c.getUser().getPhone(),
+                        c.getServiceTypes()
+                ))
+                .toList();
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverRepository.java
@@ -1,0 +1,7 @@
+package jaega.homecare.domain.caregiver.repository;
+
+import jaega.homecare.domain.caregiver.entity.Caregiver;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CaregiverRepository extends JpaRepository<Caregiver, Long>{
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/service/command/CaregiverCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/service/command/CaregiverCommandService.java
@@ -1,0 +1,28 @@
+package jaega.homecare.domain.caregiver.service.command;
+
+import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.domain.caregiver.repository.CaregiverRepository;
+import jaega.homecare.domain.center.dto.req.CreateCaregiverRequest;
+import jaega.homecare.domain.center.entity.Center;
+import jaega.homecare.domain.caregiver.mapper.CaregiverMapper;
+import jaega.homecare.domain.users.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CaregiverCommandService {
+
+    private final CaregiverMapper caregiverMapper;
+    private final CaregiverRepository caregiverRepository;
+
+    public void createCaregiver(CreateCaregiverRequest createCaregiverRequest, User user, Center center) {
+        String address = createCaregiverRequest.address();
+        Caregiver caregiver = caregiverMapper.toEntity(address, user, center);
+        caregiver.initializeCaregiver(UUID.randomUUID());
+
+        caregiverRepository.save(caregiver);
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/service/query/CaregiverQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/service/query/CaregiverQueryService.java
@@ -1,0 +1,20 @@
+package jaega.homecare.domain.caregiver.service.query;
+
+import jaega.homecare.domain.caregiver.repository.CaregiverQueryRepository;
+import jaega.homecare.domain.center.dto.res.GetCaregiverResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CaregiverQueryService {
+
+    private final CaregiverQueryRepository caregiverRepository;
+
+    public List<GetCaregiverResponse> getAllCaregiversByCenter(UUID centerId) {
+        return caregiverRepository.findAllByCenterId(centerId);
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
@@ -1,0 +1,28 @@
+package jaega.homecare.domain.center.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jaega.homecare.domain.center.dto.req.CreateCaregiverRequest;
+import jaega.homecare.domain.center.dto.res.GetCaregiverResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Tag(name = "Center", description = "Center 서비스 API")
+@RequestMapping("/api/center")
+public interface CenterController {
+
+    @Operation(summary = "보호사 등록 API", description = "입력받은 정보로 새로운 요양 보호사를 등록합니다." +
+                                                        "요양 보호사 계정은 최초 등록 시 자동으로 생성됩니다.")
+    @ApiResponse(responseCode = "204", description = "요양 보호사 등록 성공")
+    @PostMapping("/{centerId}/caregiver")
+    ResponseEntity<Void> createCaregiver(@RequestBody CreateCaregiverRequest createCaregiverRequest, @PathVariable UUID centerId);
+
+    @Operation(summary = "보호사 목록 조회 API", description = "센터에 소속된 요양 보호사를 모두 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "요양 보호사 전체 조회 성공")
+    @GetMapping("/{centerId}/caregiver")
+    ResponseEntity<List<GetCaregiverResponse>> getAllCaregivers(@PathVariable UUID centerId);
+}

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
@@ -1,0 +1,46 @@
+package jaega.homecare.domain.center.controller;
+
+import jaega.homecare.domain.caregiver.service.command.CaregiverCommandService;
+import jaega.homecare.domain.caregiver.service.query.CaregiverQueryService;
+import jaega.homecare.domain.center.dto.req.CreateCaregiverRequest;
+import jaega.homecare.domain.center.dto.res.GetCaregiverResponse;
+import jaega.homecare.domain.center.entity.Center;
+import jaega.homecare.domain.center.service.command.CenterCommandService;
+import jaega.homecare.domain.center.service.query.CenterQueryService;
+import jaega.homecare.domain.users.entity.User;
+import jaega.homecare.domain.users.entity.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/center")
+public class CenterControllerImpl implements CenterController{
+
+    private final CenterCommandService centerCommandService;
+    private final CenterQueryService centerQueryService;
+    private final CaregiverCommandService caregiverCommandService;
+    private final CaregiverQueryService caregiverQueryService;
+
+    @Override
+    public ResponseEntity<Void> createCaregiver(@RequestBody CreateCaregiverRequest createCaregiverRequest, @PathVariable UUID centerId){
+        User user = centerCommandService.createUser(createCaregiverRequest, UserRole.ROLE_CAREGIVER);
+        Center center = centerQueryService.getCenterByUUID(centerId);
+        caregiverCommandService.createCaregiver(createCaregiverRequest, user, center);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<List<GetCaregiverResponse>> getAllCaregivers(@PathVariable UUID centerId){
+        List<GetCaregiverResponse> caregivers = caregiverQueryService.getAllCaregiversByCenter(centerId);
+        return ResponseEntity.ok(caregivers);
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/center/dto/req/CreateCaregiverRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/dto/req/CreateCaregiverRequest.java
@@ -1,0 +1,11 @@
+package jaega.homecare.domain.center.dto.req;
+
+import java.time.LocalDate;
+
+public record CreateCaregiverRequest(
+        String name,
+        String email,
+        String phone,
+        LocalDate birthDate,
+        String address
+){ }

--- a/homecare/src/main/java/jaega/homecare/domain/center/dto/res/GetCaregiverResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/dto/res/GetCaregiverResponse.java
@@ -1,0 +1,13 @@
+package jaega.homecare.domain.center.dto.res;
+
+import jaega.homecare.domain.caregiver.entity.ServiceType;
+
+import java.util.Set;
+import java.util.UUID;
+
+public record GetCaregiverResponse(
+        UUID caregiverId,
+        String name,
+        String phone,
+        Set<ServiceType> serviceTypes
+) { }

--- a/homecare/src/main/java/jaega/homecare/domain/center/entity/Center.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/entity/Center.java
@@ -1,0 +1,32 @@
+package jaega.homecare.domain.center.entity;
+
+import jaega.homecare.domain.users.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "center")
+@NoArgsConstructor
+public class Center {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(name = "center_id", unique = true)
+    private UUID centerId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String name;
+
+    private String center_address;
+
+    private String contact_number;
+
+}

--- a/homecare/src/main/java/jaega/homecare/domain/center/repository/CenterRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/repository/CenterRepository.java
@@ -1,0 +1,12 @@
+package jaega.homecare.domain.center.repository;
+
+import jaega.homecare.domain.center.entity.Center;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CenterRepository extends JpaRepository<Center, Long> {
+
+    Optional<Center> findByCenterId(UUID centerId);
+}

--- a/homecare/src/main/java/jaega/homecare/domain/center/service/command/CenterCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/service/command/CenterCommandService.java
@@ -1,0 +1,51 @@
+package jaega.homecare.domain.center.service.command;
+
+import jaega.homecare.domain.center.dto.req.CreateCaregiverRequest;
+import jaega.homecare.domain.caregiver.mapper.CaregiverMapper;
+import jaega.homecare.domain.users.entity.User;
+import jaega.homecare.domain.users.entity.UserRole;
+import jaega.homecare.domain.users.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CenterCommandService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final CaregiverMapper caregiverMapper;
+
+    // 유저 생성
+    // (이 부분이 기현 님이 작성하신 메소드와 겹치는 부분입니다.)
+    public User createUser(CreateCaregiverRequest createCaregiverRequest, UserRole role) {
+        if (userRepository.existsByEmail(createCaregiverRequest.email())) {
+            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+        }
+
+        String rawPassword = generateRandomPassword(8);
+        String encodedPassword = passwordEncoder.encode(rawPassword);
+
+        User user = caregiverMapper.toUserEntity(createCaregiverRequest, encodedPassword);
+        user.setUser(UUID.randomUUID(), role, LocalDateTime.now());
+
+        return userRepository.save(user);
+    }
+
+    // 랜덤 비밀번호 생성
+    private String generateRandomPassword(int length) {
+        String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        SecureRandom random = new SecureRandom();
+
+        return random.ints(length, 0, chars.length())
+                .mapToObj(i -> String.valueOf(chars.charAt(i)))
+                .collect(Collectors.joining());
+    }
+
+}

--- a/homecare/src/main/java/jaega/homecare/domain/center/service/query/CenterQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/service/query/CenterQueryService.java
@@ -1,0 +1,21 @@
+package jaega.homecare.domain.center.service.query;
+
+import jaega.homecare.domain.center.entity.Center;
+import jaega.homecare.domain.center.repository.CenterRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CenterQueryService {
+
+    private final CenterRepository centerRepository;
+
+    public Center getCenterByUUID(UUID centerId) {
+        return centerRepository.findByCenterId(centerId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 centerId로 센터를 찾을 수 없습니다."));
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/controller/ServiceRequestController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/controller/ServiceRequestController.java
@@ -24,10 +24,10 @@ public interface ServiceRequestController {
     @Operation(summary  = "수요자가 신청한 서비스 내역 조회 API", description = "수요자가 신청한 서비스를 조회합니다.")
     @ApiResponse(responseCode = "200", description = "수요자가 신청한 서비스 내역 조회 성공")
     @GetMapping
-    public ResponseEntity<List<ConsumerServiceResponse>> getConsumerServiceRequest(@RequestParam UUID userId);
+    ResponseEntity<List<ConsumerServiceResponse>> getConsumerServiceRequest(@RequestParam UUID userId);
 
     @Operation(summary  = "수요자가 신청한 서비스 내역 조회 API (신청 서비스 상태 조건)", description = "수요자가 신청한 서비스를 신청한 서비스의 상태를 조건으로 조회합니다.")
     @ApiResponse(responseCode = "200", description = "수요자가 신청한 서비스 내역 신청 상태를 조건으로 조회 성공")
     @GetMapping("/status")
-    public ResponseEntity<List<ConsumerServiceResponse>> getConsumerServiceRequestByStatus(@RequestParam UUID userId, ServiceRequestStatus status);
+    ResponseEntity<List<ConsumerServiceResponse>> getConsumerServiceRequestByStatus(@RequestParam UUID userId, ServiceRequestStatus status);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/users/service/command/ConsumerCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/service/command/ConsumerCommandService.java
@@ -15,13 +15,13 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class ConsumerCommandService {
 
     private final UserRepository userRepository;
     private final ConsumerMapper consumerMapper;
     private final PasswordEncoder passwordEncoder;
 
-    @Transactional
     public void createUser(ConsumerCreateRequest request, UserRole role){
         if (userRepository.existsByEmail(request.email())) {
             throw new IllegalArgumentException("이미 존재하는 이메일입니다.");

--- a/homecare/src/main/java/jaega/homecare/global/config/QueryDslConfig.java
+++ b/homecare/src/main/java/jaega/homecare/global/config/QueryDslConfig.java
@@ -1,0 +1,15 @@
+package jaega.homecare.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #3, #6 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 1. Center 패키지 세팅
ERD를 기반으로 Center Entity를 작성하고 기본적인 패키지 세팅을 완료하였습니다.
### 2. Caregiver 패키지 세팅
ERD를 기반으로 Caregiver Entity를 작성하고 기본적인 패키지 세팅을 완료하였습니다. `serviceTypes` 와 ` daysOff`는 `@ElementCollection`을 사용하여 작성하였습니다. 
### 3. 요양보호사 등록 API 구현
해당 API는 `Center`패키지 하위에 작성하였습니다. 이후 연관된 서비스 메소드를 작성하면서 `CaregiverCommandService`로 옮기는게 더 적절하다고 판단되는 메소드들이 다수 존재하여, `Mapper`와 서비스 메소드 일부를 옮겨주었습니다. 이 과정에서 `User ` 를 생성하는 메소드는 `CenterCommadnService`에 남겨두었는데, 이는 기현 님께서 작성하신 부분과 유사한 메소드여서 추후 수정이 고려되었기 때문에 남겨두었습니다.
### 4. 요양보호사 조회 API 구현
해당 API는 `Center`패키지 하위에 작성하였습니다. `QueryDslConfig` 가 추가 되었으며, `CaregiverQueryRepository` 에 QueryDSL을 사용하여 구현하였습니다.

### 스크린샷 (선택)

<br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
