### PR TITLE
[#14] 매칭 알고리즘 사전 필터링 적용 및 연동

### DIFF
--- a/homecare/build.gradle
+++ b/homecare/build.gradle
@@ -55,6 +55,9 @@ dependencies {
 	// MapStruct
 	implementation 'org.mapstruct:mapstruct:1.6.3'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+
+	// Webflux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/homecare/src/main/java/jaega/homecare/domain/WorkLog/dto/res/GetWorkLogByDateResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkLog/dto/res/GetWorkLogByDateResponse.java
@@ -2,8 +2,10 @@ package jaega.homecare.domain.WorkLog.dto.res;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.UUID;
 
 public record GetWorkLogByDateResponse(
+        UUID workLogId,
         LocalDate workingDate,
         LocalTime workTimeStart,
         LocalTime workTimeEnd,

--- a/homecare/src/main/java/jaega/homecare/domain/WorkLog/dto/res/GetWorkLogByPaid.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkLog/dto/res/GetWorkLogByPaid.java
@@ -1,8 +1,10 @@
 package jaega.homecare.domain.WorkLog.dto.res;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 public record GetWorkLogByPaid(
+        UUID workLogId,
         LocalDate workingDate,
         String caregiverName
 ) {

--- a/homecare/src/main/java/jaega/homecare/domain/WorkLog/dto/res/GetWorkLogResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkLog/dto/res/GetWorkLogResponse.java
@@ -1,8 +1,10 @@
 package jaega.homecare.domain.WorkLog.dto.res;
 
 import java.time.LocalTime;
+import java.util.UUID;
 
 public record GetWorkLogResponse(
+        UUID workLogId,
         LocalTime workTime_start,
         LocalTime workTime_end,
         Double distanceLog,

--- a/homecare/src/main/java/jaega/homecare/domain/WorkLog/repository/WorkLogQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkLog/repository/WorkLogQueryRepository.java
@@ -5,6 +5,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import jaega.homecare.domain.WorkLog.dto.res.GetWorkLogByDateResponse;
 import jaega.homecare.domain.WorkLog.dto.res.GetWorkLogByPaid;
 import jaega.homecare.domain.WorkLog.entity.QWorkLog;
+import jaega.homecare.domain.WorkLog.entity.WorkLog;
 import jaega.homecare.domain.WorkMatch.entity.QWorkMatch;
 import jaega.homecare.domain.caregiver.entity.QCaregiver;
 import jaega.homecare.domain.users.entity.QUser;
@@ -29,6 +30,7 @@ public class WorkLogQueryRepository {
         return queryFactory
                 .select(Projections.constructor(
                         GetWorkLogByDateResponse.class,
+                        workLog.workLogId,
                         workMatch.workDate,
                         workLog.workTime_start,
                         workLog.workTime_end,
@@ -51,6 +53,7 @@ public class WorkLogQueryRepository {
         return queryFactory
                 .select(Projections.constructor(
                         GetWorkLogByPaid.class,
+                        workLog.workLogId,
                         workMatch.workDate,
                         caregiver.user.name
                 ))

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetCaregiverMatchesByMonth.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetCaregiverMatchesByMonth.java
@@ -3,8 +3,10 @@ package jaega.homecare.domain.WorkMatch.dto.res;
 import jaega.homecare.domain.WorkMatch.entity.WorkStatus;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 public record GetCaregiverMatchesByMonth(
+        UUID workMatchId,
         String caregiverName,
         LocalDate workDate,
         WorkStatus status

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetCaregiverMatchesResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetCaregiverMatchesResponse.java
@@ -3,8 +3,10 @@ package jaega.homecare.domain.WorkMatch.dto.res;
 import jaega.homecare.domain.WorkMatch.entity.WorkStatus;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 public record GetCaregiverMatchesResponse(
+        UUID workMatchId,
         LocalDate workDate,
         WorkStatus status
 ) {

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
@@ -29,6 +29,7 @@ public class WorkMatchQueryRepository {
         return queryFactory
                 .select(Projections.constructor(
                         GetCaregiverMatchesByMonth.class,
+                        workMatch.workMatchId,
                         user.name,
                         workMatch.workDate,
                         workMatch.status

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
@@ -4,12 +4,16 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesByMonth;
 import jaega.homecare.domain.WorkMatch.entity.QWorkMatch;
+import jaega.homecare.domain.WorkMatch.entity.WorkMatch;
+import jaega.homecare.domain.WorkMatch.entity.WorkStatus;
+import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.caregiver.entity.QCaregiver;
 import jaega.homecare.domain.users.entity.QUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 @Repository
@@ -39,6 +43,26 @@ public class WorkMatchQueryRepository {
                 .join(caregiver.user, user)
                 .where(workMatch.workDate.between(start, end))
                 .orderBy(workMatch.workDate.desc())
+                .fetch();
+    }
+
+    public List<WorkMatch> findOverlappingWorkMatches(
+            Caregiver caregiver,
+            LocalDate date,
+            LocalTime startTime,
+            LocalTime endTime
+    ) {
+        QWorkMatch wm = QWorkMatch.workMatch;
+
+        return queryFactory
+                .selectFrom(wm)
+                .where(
+                        wm.caregiver.eq(caregiver),
+                        wm.workDate.eq(date),
+                        wm.status.eq(WorkStatus.PLANNED),
+                        wm.startTime.lt(endTime),
+                        wm.endTime.gt(startTime)
+                )
                 .fetch();
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
@@ -1,5 +1,6 @@
 package jaega.homecare.domain.caregiver.entity;
 
+import jaega.homecare.domain.center.dto.req.CreateCaregiverProfileRequest;
 import jaega.homecare.domain.center.entity.Center;
 import jaega.homecare.domain.users.entity.User;
 import jakarta.persistence.*;
@@ -74,4 +75,11 @@ public class Caregiver {
         this.caregiverId = uuid;
     }
 
+    public void setCaregiverProfile(CreateCaregiverProfileRequest request){
+        this.availableStartTime = request.availableStartTIme();
+        this.availableEndTime = request.availableEndTime();
+        this.address = request.address();
+        this.serviceTypes = request.serviceTypes();
+        this.daysOff = request.daysOff();
+    }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
@@ -2,6 +2,7 @@ package jaega.homecare.domain.caregiver.entity;
 
 import jaega.homecare.domain.center.dto.req.CreateCaregiverProfileRequest;
 import jaega.homecare.domain.center.entity.Center;
+import jaega.homecare.domain.users.entity.Location;
 import jaega.homecare.domain.users.entity.User;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -45,6 +46,9 @@ public class Caregiver {
     @Column(name = "address")
     private String address;
 
+    @Embedded
+    private Location location;
+
     // 서비스 유형 (다중 선택 가능)
     @ElementCollection(targetClass = ServiceType.class, fetch = FetchType.LAZY)
     @CollectionTable(name = "service_type", joinColumns = @JoinColumn(name = "caregiver_id"))
@@ -59,6 +63,11 @@ public class Caregiver {
     @Column(name = "day_of_week")
     private Set<DayOfWeek> daysOff = new HashSet<>();
 
+    @Enumerated(EnumType.STRING)
+    private CaregiverStatus status;
+
+    private String personalityType;
+
     @Builder
     public Caregiver(UUID caregiverId, User user, Center center, LocalTime availableStartTime, LocalTime availableEndTime, String address, Set<ServiceType> serviceTypes, Set<DayOfWeek> daysOff) {
         this.caregiverId = caregiverId;
@@ -69,6 +78,7 @@ public class Caregiver {
         this.address = address;
         this.serviceTypes = serviceTypes;
         this.daysOff = daysOff;
+        this.status = CaregiverStatus.ACTIVE;
     }
 
     public void initializeCaregiver(UUID uuid) {
@@ -79,6 +89,7 @@ public class Caregiver {
         this.availableStartTime = request.availableStartTIme();
         this.availableEndTime = request.availableEndTime();
         this.address = request.address();
+        this.location = request.location();
         this.serviceTypes = request.serviceTypes();
         this.daysOff = request.daysOff();
     }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/CaregiverStatus.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/CaregiverStatus.java
@@ -1,0 +1,7 @@
+package jaega.homecare.domain.caregiver.entity;
+
+public enum CaregiverStatus {
+    ACTIVE,     // 활동중
+    ON_LEAVE,   // 휴직
+    RESIGNED    // 퇴사
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverRepository.java
@@ -1,11 +1,15 @@
 package jaega.homecare.domain.caregiver.repository;
 
 import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.domain.caregiver.entity.CaregiverStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface CaregiverRepository extends JpaRepository<Caregiver, Long>{
     Optional<Caregiver> findByCaregiverId(UUID caregiverId);
+
+    List<Caregiver> findAllByStatus(CaregiverStatus status);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/service/command/CaregiverCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/service/command/CaregiverCommandService.java
@@ -2,10 +2,13 @@ package jaega.homecare.domain.caregiver.service.command;
 
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.caregiver.repository.CaregiverRepository;
+import jaega.homecare.domain.caregiver.service.query.CaregiverQueryService;
+import jaega.homecare.domain.center.dto.req.CreateCaregiverProfileRequest;
 import jaega.homecare.domain.center.dto.req.CreateCaregiverRequest;
 import jaega.homecare.domain.center.entity.Center;
 import jaega.homecare.domain.caregiver.mapper.CaregiverMapper;
 import jaega.homecare.domain.users.entity.User;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,15 +16,24 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CaregiverCommandService {
 
     private final CaregiverMapper caregiverMapper;
     private final CaregiverRepository caregiverRepository;
+    private final CaregiverQueryService caregiverQueryService;
 
     public void createCaregiver(CreateCaregiverRequest createCaregiverRequest, User user, Center center) {
         String address = createCaregiverRequest.address();
         Caregiver caregiver = caregiverMapper.toEntity(address, user, center);
         caregiver.initializeCaregiver(UUID.randomUUID());
+
+        caregiverRepository.save(caregiver);
+    }
+
+    public void createCaregiverProfile(CreateCaregiverProfileRequest request){
+        Caregiver caregiver = caregiverQueryService.getCaregiver(request.caregiverId());
+        caregiver.setCaregiverProfile(request);
 
         caregiverRepository.save(caregiver);
     }

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
@@ -1,12 +1,15 @@
 package jaega.homecare.domain.center.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesByMonth;
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesResponse;
+import jaega.homecare.domain.center.dto.req.CenterLoginRequest;
 import jaega.homecare.domain.center.dto.req.CreateCaregiverProfileRequest;
 import jaega.homecare.domain.center.dto.req.CreateCaregiverRequest;
+import jaega.homecare.domain.center.dto.res.CenterLoginResponse;
 import jaega.homecare.domain.center.dto.res.GetCaregiverResponse;
 import jaega.homecare.domain.serviceMatch.dto.res.GetServiceMatchByCenterResponse;
 import jaega.homecare.domain.serviceMatch.dto.res.GetServiceMatchByUUID;
@@ -25,6 +28,11 @@ public interface CenterController {
     @ApiResponse(responseCode = "204", description = "요양 보호사 등록 성공")
     @PostMapping("/{centerId}/caregiver")
     ResponseEntity<Void> createCaregiver(@RequestBody CreateCaregiverRequest createCaregiverRequest, @PathVariable UUID centerId);
+
+    @Operation(summary = "센터 로그인 API", description = "입력받은 정보로 센터의 로그인을 진행합니다.")
+    @ApiResponse(responseCode = "200", description = "센터 로그인 성공")
+    @PostMapping("/login")
+    ResponseEntity<CenterLoginResponse> loginCenter(@RequestBody CenterLoginRequest request);
 
     @Operation(summary = "보호사 상세 정보 등록 API", description = "입력받은 정보로 요양보호사의 프로필을 등록합니다.")
     @ApiResponse(responseCode = "204", description = "요양 보호사 상세 정보 등록 성공")

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
@@ -8,6 +8,7 @@ import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesResponse;
 import jaega.homecare.domain.center.dto.req.CreateCaregiverRequest;
 import jaega.homecare.domain.center.dto.res.GetCaregiverResponse;
 import jaega.homecare.domain.serviceMatch.dto.res.GetServiceMatchByCenterResponse;
+import jaega.homecare.domain.serviceMatch.dto.res.GetServiceMatchByUUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -46,4 +47,10 @@ public interface CenterController {
             @RequestParam int year,
             @RequestParam int month
     );
+
+    @Operation(summary = "센터의 특정 서비스 매칭 정보 조회 API", description = "센터에서 서비스 매칭 UUID를 기반으로 서비스 매칭 정보를 상세 조회합니다.<br>" +
+            "센터에서 1. 배정 내역 전체 조회를 하고 리턴된 UUID를 기반으로 이 API를 호출하는 느낌으로 구현했습니다.")
+    @ApiResponse(responseCode = "200", description = "특정 서비스 정보 조회 API")
+    @GetMapping("/schedule/detail/{serviceMatchId}")
+    ResponseEntity<GetServiceMatchByUUID> getMatchesByUUID(@PathVariable UUID serviceMatchId);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesByMonth;
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesResponse;
+import jaega.homecare.domain.center.dto.req.CreateCaregiverProfileRequest;
 import jaega.homecare.domain.center.dto.req.CreateCaregiverRequest;
 import jaega.homecare.domain.center.dto.res.GetCaregiverResponse;
 import jaega.homecare.domain.serviceMatch.dto.res.GetServiceMatchByCenterResponse;
@@ -24,6 +25,11 @@ public interface CenterController {
     @ApiResponse(responseCode = "204", description = "요양 보호사 등록 성공")
     @PostMapping("/{centerId}/caregiver")
     ResponseEntity<Void> createCaregiver(@RequestBody CreateCaregiverRequest createCaregiverRequest, @PathVariable UUID centerId);
+
+    @Operation(summary = "보호사 상세 정보 등록 API", description = "입력받은 정보로 요양보호사의 프로필을 등록합니다.")
+    @ApiResponse(responseCode = "204", description = "요양 보호사 상세 정보 등록 성공")
+    @PostMapping("/caregiver")
+    ResponseEntity<Void> createCaregiverProfile(@RequestBody CreateCaregiverProfileRequest request);
 
     @Operation(summary = "보호사 목록 조회 API", description = "센터에 소속된 요양 보호사를 모두 조회합니다.")
     @ApiResponse(responseCode = "200", description = "요양 보호사 전체 조회 성공")

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
@@ -11,6 +11,7 @@ import jaega.homecare.domain.center.entity.Center;
 import jaega.homecare.domain.center.service.command.CenterCommandService;
 import jaega.homecare.domain.center.service.query.CenterQueryService;
 import jaega.homecare.domain.serviceMatch.dto.res.GetServiceMatchByCenterResponse;
+import jaega.homecare.domain.serviceMatch.dto.res.GetServiceMatchByUUID;
 import jaega.homecare.domain.serviceMatch.service.query.ServiceMatchQueryService;
 import jaega.homecare.domain.users.entity.User;
 import jaega.homecare.domain.users.entity.UserRole;
@@ -66,6 +67,12 @@ public class CenterControllerImpl implements CenterController{
             @RequestParam int month
     ) {
         List<GetCaregiverMatchesByMonth> response = workMatchQueryService.getWorkMatchesByMonth(year, month);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<GetServiceMatchByUUID> getMatchesByUUID(@PathVariable UUID serviceMatchId){
+        GetServiceMatchByUUID response = serviceMatchQueryService.getMatchesByUUID(serviceMatchId);
         return ResponseEntity.ok(response);
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
@@ -5,6 +5,7 @@ import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesResponse;
 import jaega.homecare.domain.WorkMatch.service.query.WorkMatchQueryService;
 import jaega.homecare.domain.caregiver.service.command.CaregiverCommandService;
 import jaega.homecare.domain.caregiver.service.query.CaregiverQueryService;
+import jaega.homecare.domain.center.dto.req.CreateCaregiverProfileRequest;
 import jaega.homecare.domain.center.dto.req.CreateCaregiverRequest;
 import jaega.homecare.domain.center.dto.res.GetCaregiverResponse;
 import jaega.homecare.domain.center.entity.Center;
@@ -40,6 +41,12 @@ public class CenterControllerImpl implements CenterController{
         Center center = centerQueryService.getCenterByUUID(centerId);
         caregiverCommandService.createCaregiver(createCaregiverRequest, user, center);
 
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> createCaregiverProfile(@RequestBody CreateCaregiverProfileRequest request){
+        caregiverCommandService.createCaregiverProfile(request);
         return ResponseEntity.noContent().build();
     }
 

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
@@ -5,8 +5,10 @@ import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesResponse;
 import jaega.homecare.domain.WorkMatch.service.query.WorkMatchQueryService;
 import jaega.homecare.domain.caregiver.service.command.CaregiverCommandService;
 import jaega.homecare.domain.caregiver.service.query.CaregiverQueryService;
+import jaega.homecare.domain.center.dto.req.CenterLoginRequest;
 import jaega.homecare.domain.center.dto.req.CreateCaregiverProfileRequest;
 import jaega.homecare.domain.center.dto.req.CreateCaregiverRequest;
+import jaega.homecare.domain.center.dto.res.CenterLoginResponse;
 import jaega.homecare.domain.center.dto.res.GetCaregiverResponse;
 import jaega.homecare.domain.center.entity.Center;
 import jaega.homecare.domain.center.service.command.CenterCommandService;
@@ -42,6 +44,12 @@ public class CenterControllerImpl implements CenterController{
         caregiverCommandService.createCaregiver(createCaregiverRequest, user, center);
 
         return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<CenterLoginResponse> loginCenter(@RequestBody CenterLoginRequest request){
+        CenterLoginResponse response = centerCommandService.loginCenter(request);
+        return ResponseEntity.ok(response);
     }
 
     @Override

--- a/homecare/src/main/java/jaega/homecare/domain/center/dto/req/CenterLoginRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/dto/req/CenterLoginRequest.java
@@ -1,0 +1,7 @@
+package jaega.homecare.domain.center.dto.req;
+
+public record CenterLoginRequest (
+        String email,
+        String password
+){
+}

--- a/homecare/src/main/java/jaega/homecare/domain/center/dto/req/CreateCaregiverProfileRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/dto/req/CreateCaregiverProfileRequest.java
@@ -1,0 +1,24 @@
+package jaega.homecare.domain.center.dto.req;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jaega.homecare.domain.caregiver.entity.ServiceType;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.Set;
+import java.util.UUID;
+
+public record CreateCaregiverProfileRequest(
+        UUID caregiverId,
+
+        @Schema(type = "string", format = "time", example = "09:00:00")
+        LocalTime availableStartTIme,
+
+        @Schema(type = "string", format = "time", example = "18:00:00")
+        LocalTime availableEndTime,
+        String address,
+        Set<ServiceType> serviceTypes,
+        Set<DayOfWeek> daysOff
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/center/dto/req/CreateCaregiverProfileRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/dto/req/CreateCaregiverProfileRequest.java
@@ -1,8 +1,8 @@
 package jaega.homecare.domain.center.dto.req;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jaega.homecare.domain.caregiver.entity.ServiceType;
+import jaega.homecare.domain.users.entity.Location;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;
@@ -18,6 +18,7 @@ public record CreateCaregiverProfileRequest(
         @Schema(type = "string", format = "time", example = "18:00:00")
         LocalTime availableEndTime,
         String address,
+        Location location,
         Set<ServiceType> serviceTypes,
         Set<DayOfWeek> daysOff
 ) {

--- a/homecare/src/main/java/jaega/homecare/domain/center/dto/res/CenterLoginResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/dto/res/CenterLoginResponse.java
@@ -1,0 +1,8 @@
+package jaega.homecare.domain.center.dto.res;
+
+import java.util.UUID;
+
+public record CenterLoginResponse(
+        UUID centerId
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/center/mapper/CenterMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/mapper/CenterMapper.java
@@ -1,0 +1,11 @@
+package jaega.homecare.domain.center.mapper;
+
+import jaega.homecare.domain.center.dto.res.CenterLoginResponse;
+import jaega.homecare.domain.center.entity.Center;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface CenterMapper {
+
+    CenterLoginResponse toLoginResponse(Center center);
+}

--- a/homecare/src/main/java/jaega/homecare/domain/center/repository/CenterRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/repository/CenterRepository.java
@@ -1,6 +1,7 @@
 package jaega.homecare.domain.center.repository;
 
 import jaega.homecare.domain.center.entity.Center;
+import jaega.homecare.domain.users.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,4 +10,6 @@ import java.util.UUID;
 public interface CenterRepository extends JpaRepository<Center, Long> {
 
     Optional<Center> findByCenterId(UUID centerId);
+
+    Optional<Center> findByUser(User user);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/center/service/command/CenterCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/service/command/CenterCommandService.java
@@ -1,11 +1,17 @@
 package jaega.homecare.domain.center.service.command;
 
+import jaega.homecare.domain.center.dto.req.CenterLoginRequest;
 import jaega.homecare.domain.center.dto.req.CreateCaregiverRequest;
 import jaega.homecare.domain.caregiver.mapper.CaregiverMapper;
+import jaega.homecare.domain.center.dto.res.CenterLoginResponse;
+import jaega.homecare.domain.center.entity.Center;
+import jaega.homecare.domain.center.mapper.CenterMapper;
+import jaega.homecare.domain.center.service.query.CenterQueryService;
 import jaega.homecare.domain.users.entity.User;
 import jaega.homecare.domain.users.entity.UserRole;
 import jaega.homecare.domain.users.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -18,8 +24,10 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class CenterCommandService {
 
+    private final CenterQueryService centerQueryService;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final CenterMapper centerMapper;
     private final CaregiverMapper caregiverMapper;
 
     // 유저 생성
@@ -36,6 +44,16 @@ public class CenterCommandService {
         user.setUser(UUID.randomUUID(), role, LocalDateTime.now());
 
         return userRepository.save(user);
+    }
+
+    public CenterLoginResponse loginCenter(CenterLoginRequest request){
+        User user = userRepository.findByEmail(request.email());
+        if (user == null || !passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new BadCredentialsException("로그인에 실패했습니다.");
+        }
+        Center center = centerQueryService.getCenterByUser(user);
+
+        return centerMapper.toLoginResponse(center);
     }
 
     // 랜덤 비밀번호 생성

--- a/homecare/src/main/java/jaega/homecare/domain/center/service/query/CenterQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/service/query/CenterQueryService.java
@@ -2,6 +2,7 @@ package jaega.homecare.domain.center.service.query;
 
 import jaega.homecare.domain.center.entity.Center;
 import jaega.homecare.domain.center.repository.CenterRepository;
+import jaega.homecare.domain.users.entity.User;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,5 +18,10 @@ public class CenterQueryService {
     public Center getCenterByUUID(UUID centerId) {
         return centerRepository.findByCenterId(centerId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 centerId로 센터를 찾을 수 없습니다."));
+    }
+
+    public Center getCenterByUser(User user){
+        return centerRepository.findByUser(user)
+                .orElseThrow(() -> new EntityNotFoundException("해당 유저 정보로 센터의 id를 가져올 수 없습니다."));
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/match/controller/MatchController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/match/controller/MatchController.java
@@ -1,0 +1,21 @@
+package jaega.homecare.domain.match.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jaega.homecare.domain.match.dto.res.MatchResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.UUID;
+
+@Tag(name = "Match", description = "매칭 알고리즘 API")
+@RequestMapping("/api/match")
+public interface MatchController {
+
+    @Operation(summary = "매칭 알고리즘 호출 API", description = "서비스 요청 ID를 기반으로 수요자의 매칭 알고리즘을 진행합니다.")
+    @ApiResponse(responseCode = "200", description = "매칭 알고리즘 호출 성공")
+    @PostMapping("/process")
+    ResponseEntity<MatchResponse> matchingProcess(UUID serviceRequestId);
+}

--- a/homecare/src/main/java/jaega/homecare/domain/match/controller/MatchControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/match/controller/MatchControllerImpl.java
@@ -1,0 +1,23 @@
+package jaega.homecare.domain.match.controller;
+
+import jaega.homecare.domain.match.dto.res.MatchResponse;
+import jaega.homecare.domain.match.service.CaregiverMatchingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/match")
+public class MatchControllerImpl implements MatchController {
+
+    private final CaregiverMatchingService caregiverMatchingService;
+    @Override
+    public ResponseEntity<MatchResponse> matchingProcess(UUID serviceRequestId) {
+         MatchResponse response = caregiverMatchingService.recommendCaregivers(serviceRequestId);
+         return ResponseEntity.ok(response);
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/match/dto/req/CaregiverDTO.java
+++ b/homecare/src/main/java/jaega/homecare/domain/match/dto/req/CaregiverDTO.java
@@ -1,0 +1,15 @@
+package jaega.homecare.domain.match.dto.req;
+
+import java.util.List;
+
+public record CaregiverDTO(
+        String caregiverId,
+        String serviceType,
+        String closedDays,
+        String availableStartTime,
+        String availableEndTime,
+        String baseAddress,
+        List<Double> baseLocation,
+        String personalityType,
+        int careerYears
+) {}

--- a/homecare/src/main/java/jaega/homecare/domain/match/dto/req/MatchRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/match/dto/req/MatchRequest.java
@@ -1,0 +1,9 @@
+package jaega.homecare.domain.match.dto.req;
+
+import java.util.List;
+
+public record MatchRequest(
+        ServiceRequestDTO request,
+        List<CaregiverDTO> candidates
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/match/dto/req/ServiceRequestDTO.java
+++ b/homecare/src/main/java/jaega/homecare/domain/match/dto/req/ServiceRequestDTO.java
@@ -1,0 +1,11 @@
+package jaega.homecare.domain.match.dto.req;
+
+import java.util.List;
+
+public record ServiceRequestDTO(
+        String serviceRequestId,
+        String address,
+        List<Double> location,
+        String serviceType,
+        List<String> requestedDays
+) {}

--- a/homecare/src/main/java/jaega/homecare/domain/match/dto/res/MatchResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/match/dto/res/MatchResponse.java
@@ -1,0 +1,9 @@
+package jaega.homecare.domain.match.dto.res;
+
+import java.util.List;
+
+public record MatchResponse(
+        List<MatchingResponseDto> matchedCaregivers,
+        int totalMatches
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/match/dto/res/MatchingResponseDto.java
+++ b/homecare/src/main/java/jaega/homecare/domain/match/dto/res/MatchingResponseDto.java
@@ -1,0 +1,15 @@
+package jaega.homecare.domain.match.dto.res;
+
+import java.util.List;
+
+public record MatchingResponseDto(
+        String caregiverId,
+        String availableStartTime,
+        String availableEndTime,
+        String address,
+        List<Double> location,
+        Double matchScore,
+        String matchReason
+) {
+
+}

--- a/homecare/src/main/java/jaega/homecare/domain/match/infra/AiRecommendation.java
+++ b/homecare/src/main/java/jaega/homecare/domain/match/infra/AiRecommendation.java
@@ -1,0 +1,41 @@
+package jaega.homecare.domain.match.infra;
+
+import jaega.homecare.domain.match.dto.req.CaregiverDTO;
+import jaega.homecare.domain.match.dto.req.ServiceRequestDTO;
+import jaega.homecare.domain.match.dto.res.MatchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class AiRecommendation {
+
+    private final WebClient webClient;
+
+    public MatchResponse sendRecommendRequest(ServiceRequestDTO request, List<CaregiverDTO> caregivers) {
+        Map<String, Object> requestBody = Map.of(
+                "serviceRequest", request,
+                "candidateCaregivers", caregivers
+        );
+
+        return webClient.post()
+                .uri("/matching/recommend")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(requestBody)
+                .retrieve()
+                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                        clientResponse -> clientResponse.bodyToMono(String.class).flatMap(errorBody -> {
+                            // 에러 로그 출력
+                            System.err.println("에러 메세지 : " + errorBody);
+                            return Mono.error(new RuntimeException("API 호출 실패: " + errorBody));
+                        }))
+                .bodyToMono(MatchResponse.class)
+                .block();
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/match/processor/CaregiverFilterProcessor.java
+++ b/homecare/src/main/java/jaega/homecare/domain/match/processor/CaregiverFilterProcessor.java
@@ -1,0 +1,47 @@
+package jaega.homecare.domain.match.processor;
+
+import jaega.homecare.domain.WorkMatch.repository.WorkMatchQueryRepository;
+import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.domain.caregiver.entity.ServiceType;
+import jaega.homecare.domain.serviceRequest.entity.ServiceRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class CaregiverFilterProcessor {
+
+    private final WorkMatchQueryRepository workMatchQueryRepository;
+
+    public List<Caregiver> filter(ServiceRequest request, List<Caregiver> candidates, LocalDate applyDate) {
+        return candidates.stream()
+           //     .filter(c -> !isDayOff(c, applyDate.getDayOfWeek()))
+                .filter(c -> isAvailableAtTime(c, request.getPreferred_time_start(), request.getPreferred_time_end()))
+                .filter(c -> supportsServiceType(c, request.getServiceType()))
+                .filter(c -> !hasOverlappingWork(c, applyDate, request.getPreferred_time_start(), request.getPreferred_time_end()))
+                .collect(Collectors.toList());
+    }
+
+    private boolean isDayOff(Caregiver caregiver, DayOfWeek day) {
+        return caregiver.getDaysOff() != null && caregiver.getDaysOff().contains(day);
+    }
+
+    private boolean isAvailableAtTime(Caregiver caregiver, LocalTime start, LocalTime end) {
+        return !caregiver.getAvailableStartTime().isAfter(start) &&
+                !caregiver.getAvailableEndTime().isBefore(end);
+    }
+
+    private boolean supportsServiceType(Caregiver caregiver, ServiceType type) {
+        return caregiver.getServiceTypes().contains(type);
+    }
+
+    private boolean hasOverlappingWork(Caregiver caregiver, LocalDate date, LocalTime start, LocalTime end) {
+        return !workMatchQueryRepository.findOverlappingWorkMatches(caregiver, date, start, end).isEmpty();
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/match/service/CaregiverMatchingService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/match/service/CaregiverMatchingService.java
@@ -1,0 +1,109 @@
+package jaega.homecare.domain.match.service;
+
+import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.domain.caregiver.entity.CaregiverStatus;
+import jaega.homecare.domain.caregiver.entity.ServiceType;
+import jaega.homecare.domain.caregiver.repository.CaregiverRepository;
+import jaega.homecare.domain.match.dto.req.CaregiverDTO;
+import jaega.homecare.domain.match.dto.req.ServiceRequestDTO;
+import jaega.homecare.domain.match.dto.res.MatchResponse;
+import jaega.homecare.domain.match.infra.AiRecommendation;
+import jaega.homecare.domain.match.processor.CaregiverFilterProcessor;
+import jaega.homecare.domain.serviceRequest.entity.ServiceRequest;
+import jaega.homecare.domain.serviceRequest.service.query.ServiceRequestQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CaregiverMatchingService {
+
+    private final ServiceRequestQueryService serviceRequestQueryService;
+    private final CaregiverRepository caregiverRepository;
+    private final CaregiverFilterProcessor filterProcessor;
+    private final AiRecommendation aiClient;
+
+    public MatchResponse recommendCaregivers(UUID serviceRequestId) {
+        ServiceRequest request = serviceRequestQueryService.getServiceRequest(serviceRequestId);
+        List<Caregiver> all = caregiverRepository.findAllByStatus(CaregiverStatus.ACTIVE);
+
+        Set<LocalDate> applyDates = request.getRequestedDays();
+
+        // 날짜별 필터링 후 결과 합치기 (중복 제거)
+        Set<Caregiver> filteredCaregivers = new HashSet<>();
+
+        for (LocalDate date : applyDates) {
+            List<Caregiver> candidates = filterProcessor.filter(request, all, date);
+            filteredCaregivers.addAll(candidates);
+        }
+
+        List<Caregiver> finalCandidates = new ArrayList<>(filteredCaregivers);
+
+        // 엔티티를 DTO로 변환
+        List<CaregiverDTO> finalCandidateDTOs = convertCaregiversToDTOs(finalCandidates);
+
+        ServiceRequestDTO dto = convertToDTO(request);
+
+        // DTO 리스트를 넘기기
+        return aiClient.sendRecommendRequest(dto, finalCandidateDTOs);
+    }
+
+    private ServiceRequestDTO convertToDTO(ServiceRequest entity) {
+        List<String> requestedDaysStr = entity.getRequestedDays().stream()
+                .map(LocalDate::toString)  // "yyyy-MM-dd" 문자열로 변환
+                .collect(Collectors.toList());
+
+        return new ServiceRequestDTO(
+                entity.getServiceRequestId().toString(),
+                entity.getAddress(),
+                List.of(entity.getLocation().getLatitude(), entity.getLocation().getLongitude()),
+                entity.getServiceType().name(),
+                requestedDaysStr
+        );
+    }
+
+
+    // Caregiver 엔티티 → CaregiverDTO 변환
+    private CaregiverDTO convertCaregiverToDTO(Caregiver caregiver) {
+        String closedDays = caregiver.getDaysOff().stream()
+                .map(day -> switch (day) {
+                    case MONDAY -> "월";
+                    case TUESDAY -> "화";
+                    case WEDNESDAY -> "수";
+                    case THURSDAY -> "목";
+                    case FRIDAY -> "금";
+                    case SATURDAY -> "토";
+                    case SUNDAY -> "일";
+                })
+                .collect(Collectors.joining(","));
+
+        String personalityType = Optional.ofNullable(caregiver.getPersonalityType())
+                .orElse("UNKNOWN");  // 기본값 지정
+
+        return new CaregiverDTO(
+                caregiver.getCaregiverId().toString(),
+                caregiver.getServiceTypes().stream().findFirst().orElse(ServiceType.VISITING_CARE).name(),
+                closedDays,
+                caregiver.getAvailableStartTime().toString(),
+                caregiver.getAvailableEndTime().toString(),
+                caregiver.getAddress(),
+                List.of(
+                        caregiver.getLocation().getLatitude(),
+                        caregiver.getLocation().getLongitude()
+                ),
+                personalityType,
+                5 // 요양보호사 경력 년차
+        );
+    }
+
+    // 여러 Caregiver 엔티티 리스트를 DTO 리스트로 변환
+    private List<CaregiverDTO> convertCaregiversToDTOs(List<Caregiver> caregivers) {
+        return caregivers.stream()
+                .map(this::convertCaregiverToDTO)
+                .collect(Collectors.toList());
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/dto/res/GetServiceMatchByConsumerResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/dto/res/GetServiceMatchByConsumerResponse.java
@@ -1,5 +1,7 @@
 package jaega.homecare.domain.serviceMatch.dto.res;
 
+import jaega.homecare.domain.caregiver.entity.ServiceType;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 
@@ -9,6 +11,6 @@ public record GetServiceMatchByConsumerResponse(
         LocalDate serviceDate,
         LocalTime startTime,
         LocalTime endTime,
-        String serviceType
+        ServiceType serviceType
 ) {
 }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/dto/res/GetServiceMatchByUUID.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/dto/res/GetServiceMatchByUUID.java
@@ -1,0 +1,13 @@
+package jaega.homecare.domain.serviceMatch.dto.res;
+
+import jaega.homecare.domain.serviceMatch.entity.MatchStatus;
+
+public record GetServiceMatchByUUID(
+        String consumerName,
+        String caregiverName,
+        String serviceDate,
+        String startTime,
+        String endTime,
+        MatchStatus status
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/mapper/ServiceMatchMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/mapper/ServiceMatchMapper.java
@@ -2,6 +2,7 @@ package jaega.homecare.domain.serviceMatch.mapper;
 
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.serviceMatch.dto.req.CreateServiceMatchRequest;
+import jaega.homecare.domain.serviceMatch.dto.res.GetServiceMatchByUUID;
 import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
 import jaega.homecare.domain.serviceRequest.entity.ServiceRequest;
 import org.mapstruct.Mapper;
@@ -20,4 +21,12 @@ public interface ServiceMatchMapper {
     @Mapping(target = "serviceMatchId", ignore = true)
     @Mapping(target = "status", ignore = true)
     ServiceMatch toEntity(CreateServiceMatchRequest request, LocalDate serviceDate, ServiceRequest serviceRequest, Caregiver caregiver);
+
+    @Mapping(target = "consumerName", source = "serviceRequest.user.name")
+    @Mapping(target = "caregiverName", source = "caregiver.user.name")
+    @Mapping(target = "serviceDate", source = "serviceDate")
+    @Mapping(target = "startTime", source = "startTime")
+    @Mapping(target = "endTime", source = "endTime")
+    @Mapping(target = "status", source = "status")
+    GetServiceMatchByUUID toGetResponseByUUID(ServiceMatch serviceMatch);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/repository/ServiceMatchRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/repository/ServiceMatchRepository.java
@@ -3,5 +3,9 @@ package jaega.homecare.domain.serviceMatch.repository;
 import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 public interface ServiceMatchRepository extends JpaRepository<ServiceMatch, Long> {
+    Optional<ServiceMatch> findByServiceMatchId(UUID serviceMatchId);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/service/query/ServiceMatchQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/service/query/ServiceMatchQueryService.java
@@ -2,12 +2,17 @@ package jaega.homecare.domain.serviceMatch.service.query;
 
 import jaega.homecare.domain.serviceMatch.dto.res.GetServiceMatchByConsumerResponse;
 import jaega.homecare.domain.serviceMatch.dto.res.GetServiceMatchByCenterResponse;
+import jaega.homecare.domain.serviceMatch.dto.res.GetServiceMatchByUUID;
+import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
+import jaega.homecare.domain.serviceMatch.mapper.ServiceMatchMapper;
 import jaega.homecare.domain.serviceMatch.repository.ServiceMatchQueryRepository;
 import jaega.homecare.domain.serviceMatch.repository.ServiceMatchRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 
 @Service
@@ -16,6 +21,13 @@ public class ServiceMatchQueryService {
 
     private final ServiceMatchRepository serviceMatchRepository;
     private final ServiceMatchQueryRepository serviceMatchQueryRepository;
+    private final ServiceMatchMapper serviceMatchMapper;
+
+    // 도메인 조회
+    public ServiceMatch getServiceMatch(UUID serviceMatchId){
+        return serviceMatchRepository.findByServiceMatchId(serviceMatchId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 serviceMatchId로 서비스 매칭 결과를 찾을 수 없습니다."));
+    }
 
     public List<GetServiceMatchByCenterResponse> getMatchesByCenter(UUID centerId) {
         return serviceMatchQueryRepository.findMatchesByCenterId(centerId);
@@ -23,6 +35,11 @@ public class ServiceMatchQueryService {
 
     public List<GetServiceMatchByConsumerResponse> getMatchesByConsumer(UUID userId){
         return serviceMatchQueryRepository.findByUserId(userId);
+    }
+
+    public GetServiceMatchByUUID getMatchesByUUID(UUID serviceMatchId){
+        ServiceMatch serviceMatch = getServiceMatch(serviceMatchId);
+        return serviceMatchMapper.toGetResponseByUUID(serviceMatch);
     }
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/dto/req/ConsumerServiceRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/dto/req/ConsumerServiceRequest.java
@@ -1,18 +1,27 @@
 package jaega.homecare.domain.serviceRequest.dto.req;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jaega.homecare.domain.caregiver.entity.ServiceType;
+
+import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Set;
 import java.util.UUID;
 
 public record ConsumerServiceRequest(
         UUID userId,
         String address,
         LocationDto location,
+
+        @Schema(description = "선호 시작 시간", example = "09:00:00")
         LocalTime preferred_time_start,
+
+        @Schema(description = "선호 종료 시간", example = "18:00:00")
         LocalTime preferred_time_end,
-        String serviceType,
+        ServiceType serviceType,
         String personalityType,
-        String requestedDays,
+        Set<LocalDate> requestedDays,
         String additionalInformation
 ) {
 }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/dto/res/GetServiceRequestResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/dto/res/GetServiceRequestResponse.java
@@ -2,7 +2,9 @@ package jaega.homecare.domain.serviceRequest.dto.res;
 
 import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Set;
 import java.util.UUID;
 
 public record GetServiceRequestResponse(
@@ -13,6 +15,6 @@ public record GetServiceRequestResponse(
         String serviceType,
         ServiceRequestStatus status,
         String personalityType,
-        String requestedDays
+        Set<LocalDate> requestedDays
 ) {
 }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/entity/ServiceRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/entity/ServiceRequest.java
@@ -1,11 +1,14 @@
 package jaega.homecare.domain.serviceRequest.entity;
 
+import jaega.homecare.domain.caregiver.entity.ServiceType;
+import jaega.homecare.domain.users.entity.Location;
 import jaega.homecare.domain.users.entity.User;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Set;
 import java.util.UUID;
@@ -34,7 +37,7 @@ public class ServiceRequest {
 
     private LocalTime preferred_time_end;
 
-    private String serviceType;
+    private ServiceType serviceType;
 
     @Enumerated(EnumType.STRING)
     private ServiceRequestStatus status;
@@ -44,13 +47,13 @@ public class ServiceRequest {
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "service_request_days", joinColumns = @JoinColumn(name = "service_request_id"))
     @Column(name = "requested_days")
-    private Set<Integer> requestedDays; // ex : 1, 3, 5, ...
+    private Set<LocalDate> requestedDays; // ex : 1, 3, 5, ...
 
     private String additionalInformation;
 
     @Builder
     public ServiceRequest(UUID serviceRequestId, User user, String address, Location location, LocalTime preferred_time_start, LocalTime preferred_time_end,
-                          String serviceType, ServiceRequestStatus status, String personalityType, Set<Integer> requestedDays, String additionalInformation){
+                          ServiceType serviceType, ServiceRequestStatus status, String personalityType, Set<LocalDate> requestedDays, String additionalInformation){
         this.address = address;
         this.location = location;
         this.preferred_time_start = preferred_time_start;
@@ -61,7 +64,7 @@ public class ServiceRequest {
         this.additionalInformation = additionalInformation;
     }
 
-    public void setServiceRequest(UUID serviceRequestId, User user, ServiceRequestStatus status, Set<Integer> requestedDays){
+    public void setServiceRequest(UUID serviceRequestId, User user, ServiceRequestStatus status, Set<LocalDate> requestedDays){
         this.serviceRequestId = serviceRequestId;
         this.user = user;
         this.status = status;

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/mapper/ServiceRequestMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/mapper/ServiceRequestMapper.java
@@ -3,13 +3,10 @@ package jaega.homecare.domain.serviceRequest.mapper;
 import jaega.homecare.domain.serviceRequest.dto.req.ConsumerServiceRequest;
 import jaega.homecare.domain.serviceRequest.dto.req.LocationDto;
 import jaega.homecare.domain.serviceRequest.dto.res.GetServiceRequestResponse;
-import jaega.homecare.domain.serviceRequest.entity.Location;
+import jaega.homecare.domain.users.entity.Location;
 import jaega.homecare.domain.serviceRequest.entity.ServiceRequest;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring")
 public interface ServiceRequestMapper {
@@ -27,20 +24,10 @@ public interface ServiceRequestMapper {
     @Mapping(target = "status", ignore = true)
     ServiceRequest toEntity(ConsumerServiceRequest request);
 
-    @Mapping(target = "requestedDays", expression = "java(convertRequestedDays(request.getRequestedDays()))")
     GetServiceRequestResponse toFindResponseDto(ServiceRequest request);
 
     default Location map(LocationDto dto) {
         if (dto == null) return null;
         return new Location(dto.latitude(), dto.longitude());
-    }
-
-
-    default String convertRequestedDays(Set<Integer> days) {
-        if (days == null || days.isEmpty()) return "";
-        return days.stream()
-                .sorted()
-                .map(String::valueOf)
-                .collect(Collectors.joining(", "));
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/service/command/ServiceRequestCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/service/command/ServiceRequestCommandService.java
@@ -11,11 +11,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -30,19 +26,8 @@ public class ServiceRequestCommandService {
         User user = userQueryService.getUser(request.userId());
 
         ServiceRequest serviceRequest = serviceRequestMapper.toEntity(request);
-        Set<Integer> requestedDaysSet = parseRequestedDays(request.requestedDays());
 
-        serviceRequest.setServiceRequest(UUID.randomUUID(), user, ServiceRequestStatus.PENDING, requestedDaysSet);
+        serviceRequest.setServiceRequest(UUID.randomUUID(), user, ServiceRequestStatus.PENDING, request.requestedDays());
         serviceRequestRepository.save(serviceRequest);
-    }
-
-    private Set<Integer> parseRequestedDays(String requestedDaysStr) {
-        if (requestedDaysStr == null || requestedDaysStr.isEmpty()) {
-            return Collections.emptySet();
-        }
-        return Arrays.stream(requestedDaysStr.split(","))
-                .map(String::trim)
-                .map(Integer::parseInt)
-                .collect(Collectors.toSet());
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/users/entity/Location.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/entity/Location.java
@@ -1,4 +1,4 @@
-package jaega.homecare.domain.serviceRequest.entity;
+package jaega.homecare.domain.users.entity;
 
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;

--- a/homecare/src/main/java/jaega/homecare/global/config/WebClientConfig.java
+++ b/homecare/src/main/java/jaega/homecare/global/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package jaega.homecare.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #14 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 1. 매칭 알고리즘 전 사전 필터링 적용
서비스 신청일, 시간, 요양보호사의 여유 근무 시간 등을 고려해서 사전 필터링을 적용했습니다.
또한, 매칭 알고리즘에 맞게 요양보호사와 ServiceRequest의 속성을 변경 및 추가했습니다.

### 2. 매칭 알고리즘 연동
구현된 매칭 알고리즘을 webclient로 연동한 후 리스트로 데이터를 전달하는 로직을 구현했습니다.

### 3. 센터 로그인 및 요양보호사 프로필 등록 api를 구현했습니다.
센터 로그인의 경우 프론트에서 센터ID를 어디서 받아올지 알 수 없어 유저의 로그인처럼 임시로 구현했습니다.
요양보호사의 프로필 등록은 매칭 알고리즘에 필요한 데이터들이 많아 유저의 정보를 수정하는 로직처럼 구현했습니다.


### 스크린샷 (선택)

<br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
