### PR TITLE
[#25] 관리자 웹 페이지의 대시보드, 정산 내역 api 추가

### DIFF
--- a/homecare/src/main/java/jaega/homecare/HomecareApplication.java
+++ b/homecare/src/main/java/jaega/homecare/HomecareApplication.java
@@ -2,8 +2,10 @@ package jaega.homecare;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class HomecareApplication {
 
 	public static void main(String[] args) {

--- a/homecare/src/main/java/jaega/homecare/domain/WorkLog/dto/res/GetDashboardSettlementResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkLog/dto/res/GetDashboardSettlementResponse.java
@@ -1,0 +1,10 @@
+package jaega.homecare.domain.WorkLog.dto.res;
+
+import java.math.BigDecimal;
+
+public record GetDashboardSettlementResponse(
+        BigDecimal totalSettledAmount,
+        Long unsettledCount,
+        Long fraudAlertCount  // 부정행위 알림 건수
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/WorkLog/entity/WorkLog.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkLog/entity/WorkLog.java
@@ -53,6 +53,10 @@ public class WorkLog extends BaseTimeEntity {
         this.isPaid = isPaid;
     }
 
+    public void togglePaidStatus(){
+        this.isPaid = !isPaid;
+    }
+
     public void setWorkLog(UUID workLogId, BigDecimal settlementAmount){
         this.workLogId = workLogId;
         this.settlementAmount = settlementAmount;

--- a/homecare/src/main/java/jaega/homecare/domain/WorkLog/entity/WorkLog.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkLog/entity/WorkLog.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalTime;
 import java.util.UUID;
 
@@ -37,6 +38,9 @@ public class WorkLog {
     @Column(name = "is_paid")
     private boolean isPaid = false;
 
+    @Column(name = "settlement_account")
+    private BigDecimal settlementAmount;
+
     @Builder
     public WorkLog(UUID workLogId, WorkMatch workMatch, LocalTime workTime_start,
                    LocalTime workTime_end, Double distanceLog, boolean isPaid){
@@ -48,7 +52,8 @@ public class WorkLog {
         this.isPaid = isPaid;
     }
 
-    public void setWorkLog(UUID workLogId){
+    public void setWorkLog(UUID workLogId, BigDecimal settlementAmount){
         this.workLogId = workLogId;
+        this.settlementAmount = settlementAmount;
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkLog/entity/WorkLog.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkLog/entity/WorkLog.java
@@ -1,6 +1,7 @@
 package jaega.homecare.domain.WorkLog.entity;
 
 import jaega.homecare.domain.WorkMatch.entity.WorkMatch;
+import jaega.homecare.global.audit.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +15,7 @@ import java.util.UUID;
 @Getter
 @Table(name = "workLog")
 @NoArgsConstructor
-public class WorkLog {
+public class WorkLog extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/homecare/src/main/java/jaega/homecare/domain/WorkLog/repository/WorkLogQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkLog/repository/WorkLogQueryRepository.java
@@ -46,6 +46,7 @@ public class WorkLogQueryRepository {
                 .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
                 .where(workMatch.workDate.eq(date)
                         .and(caregiverCenter.center.centerId.eq(centerId)))
+                .orderBy(workLog.workTime_start.asc())
                 .fetch();
     }
 
@@ -70,6 +71,8 @@ public class WorkLogQueryRepository {
                 .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
                 .where(workLog.isPaid.eq(isPaid)
                         .and(caregiverCenter.center.centerId.eq(centerId)))
+                .orderBy(
+                        workMatch.workDate.desc())
                 .fetch();
     }
 

--- a/homecare/src/main/java/jaega/homecare/domain/WorkLog/repository/WorkLogQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkLog/repository/WorkLogQueryRepository.java
@@ -12,6 +12,7 @@ import jaega.homecare.domain.users.entity.QUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
@@ -66,5 +67,42 @@ public class WorkLogQueryRepository {
                 .where(workLog.isPaid.eq(isPaid)
                         .and(caregiver.center.centerId.eq(centerId)))
                 .fetch();
+    }
+
+
+    // 이번 달 누적 정산 금액 조회
+    public BigDecimal getTotalSettledAmountThisMonth(UUID centerId) {
+        QWorkLog workLog = QWorkLog.workLog;
+        QWorkMatch workMatch = QWorkMatch.workMatch;
+        QCaregiver caregiver = QCaregiver.caregiver;
+
+        LocalDate now = LocalDate.now();
+        LocalDate firstDay = now.withDayOfMonth(1);
+
+        return queryFactory
+                .select(workLog.settlementAmount.sum())
+                .from(workLog)
+                .join(workLog.workMatch, workMatch)
+                .join(workMatch.caregiver, caregiver)
+                .where(workLog.isPaid.eq(true)
+                        .and(workMatch.workDate.goe(firstDay))
+                        .and(caregiver.center.centerId.eq(centerId)))
+                .fetchOne();
+    }
+
+    // 미정산 건수 조회
+    public Long countUnsettled(UUID centerId) {
+        QWorkLog workLog = QWorkLog.workLog;
+        QWorkMatch workMatch = QWorkMatch.workMatch;
+        QCaregiver caregiver = QCaregiver.caregiver;
+
+        return queryFactory
+                .select(workLog.count())
+                .from(workLog)
+                .join(workLog.workMatch, workMatch)
+                .join(workMatch.caregiver, caregiver)
+                .where(workLog.isPaid.eq(false)
+                        .and(caregiver.center.centerId.eq(centerId)))
+                .fetchOne();
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkLog/repository/WorkLogQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkLog/repository/WorkLogQueryRepository.java
@@ -79,6 +79,7 @@ public class WorkLogQueryRepository {
         QWorkLog workLog = QWorkLog.workLog;
         QWorkMatch workMatch = QWorkMatch.workMatch;
         QCaregiver caregiver = QCaregiver.caregiver;
+        QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
 
         LocalDate now = LocalDate.now();
         LocalDate firstDay = now.withDayOfMonth(1);
@@ -88,9 +89,10 @@ public class WorkLogQueryRepository {
                 .from(workLog)
                 .join(workLog.workMatch, workMatch)
                 .join(workMatch.caregiver, caregiver)
+                .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
                 .where(workLog.isPaid.eq(true)
                         .and(workMatch.workDate.goe(firstDay))
-                        .and(caregiver.center.centerId.eq(centerId)))
+                        .and(caregiverCenter.center.centerId.eq(centerId)))
                 .fetchOne();
     }
 
@@ -99,14 +101,16 @@ public class WorkLogQueryRepository {
         QWorkLog workLog = QWorkLog.workLog;
         QWorkMatch workMatch = QWorkMatch.workMatch;
         QCaregiver caregiver = QCaregiver.caregiver;
+        QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
 
         return queryFactory
                 .select(workLog.count())
                 .from(workLog)
                 .join(workLog.workMatch, workMatch)
                 .join(workMatch.caregiver, caregiver)
+                .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
                 .where(workLog.isPaid.eq(false)
-                        .and(caregiver.center.centerId.eq(centerId)))
+                        .and(caregiverCenter.center.centerId.eq(centerId)))
                 .fetchOne();
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkLog/repository/WorkLogRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkLog/repository/WorkLogRepository.java
@@ -1,6 +1,7 @@
 package jaega.homecare.domain.WorkLog.repository;
 
 import jaega.homecare.domain.WorkLog.entity.WorkLog;
+import jaega.homecare.domain.WorkMatch.entity.WorkMatch;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,5 +10,7 @@ import java.util.UUID;
 
 public interface WorkLogRepository extends JpaRepository<WorkLog, Long> {
     Optional<WorkLog> findByWorkLogId(UUID workLogId);
+
+    List<WorkLog> findByWorkMatch(WorkMatch workMatch);
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkLog/service/command/WorkLogCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkLog/service/command/WorkLogCommandService.java
@@ -22,6 +22,16 @@ public class WorkLogCommandService {
     private final WorkLogRepository workLogRepository;
     private final WorkLogMapper workLogMapper;
 
+    /**
+     * 특정 WorkLog의 정산 상태 변경
+     */
+    public void togglePaidStatus(UUID workLogId) {
+        WorkLog workLog = workLogRepository.findByWorkLogId(workLogId)
+                .orElseThrow(() -> new IllegalArgumentException("WorkLog not found: " + workLogId));
+
+        workLog.togglePaidStatus();
+    }
+
     public void createWorkLog(CreateWorkLogRequest request){
 
         BigDecimal settlementAccount = calculateSettlementAmount(request.workTime_start(), request.workTime_end(), request.distanceLog());

--- a/homecare/src/main/java/jaega/homecare/domain/WorkLog/service/command/WorkLogCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkLog/service/command/WorkLogCommandService.java
@@ -8,6 +8,9 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.LocalTime;
 import java.util.UUID;
 
 @Service
@@ -20,8 +23,26 @@ public class WorkLogCommandService {
 
     public void createWorkLog(CreateWorkLogRequest request){
 
+        BigDecimal settlementAccount = calculateSettlementAmount(request.workTime_start(), request.workTime_end(), request.distanceLog());
+
         WorkLog workLog = workLogMapper.toEntity(request);
-        workLog.setWorkLog(UUID.randomUUID());
+        workLog.setWorkLog(UUID.randomUUID(), settlementAccount);
         workLogRepository.save(workLog);
+    }
+
+    public BigDecimal calculateSettlementAmount(LocalTime start, LocalTime end, Double distanceKm) {
+        BigDecimal hourlyRate = new BigDecimal("15000");  // 시간당 단가
+        BigDecimal distanceRate = new BigDecimal("500");  // 거리당 단가
+
+        // 근무 시간 계산 (분 단위 -> 시간 단위로 변환)
+        long minutes = Duration.between(start, end).toMinutes();
+        BigDecimal hours = BigDecimal.valueOf(minutes).divide(BigDecimal.valueOf(60), 2, BigDecimal.ROUND_HALF_UP);
+
+        // 거리
+        BigDecimal distance = BigDecimal.valueOf(distanceKm != null ? distanceKm : 0);
+
+        // 금액 계산
+        BigDecimal amount = hourlyRate.multiply(hours).add(distanceRate.multiply(distance));
+        return amount.setScale(0, BigDecimal.ROUND_HALF_UP);  // 반올림, 소수점 없애기
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkLog/service/command/WorkLogCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkLog/service/command/WorkLogCommandService.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Duration;
 import java.time.LocalTime;
 import java.util.UUID;
@@ -36,13 +37,13 @@ public class WorkLogCommandService {
 
         // 근무 시간 계산 (분 단위 -> 시간 단위로 변환)
         long minutes = Duration.between(start, end).toMinutes();
-        BigDecimal hours = BigDecimal.valueOf(minutes).divide(BigDecimal.valueOf(60), 2, BigDecimal.ROUND_HALF_UP);
+        BigDecimal hours = BigDecimal.valueOf(minutes).divide(BigDecimal.valueOf(60), 2, RoundingMode.HALF_UP);
 
         // 거리
         BigDecimal distance = BigDecimal.valueOf(distanceKm != null ? distanceKm : 0);
 
         // 금액 계산
         BigDecimal amount = hourlyRate.multiply(hours).add(distanceRate.multiply(distance));
-        return amount.setScale(0, BigDecimal.ROUND_HALF_UP);  // 반올림, 소수점 없애기
+        return amount.setScale(0, RoundingMode.HALF_UP);  // 반올림, 소수점 없애기
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkLog/service/query/WorkLogQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkLog/service/query/WorkLogQueryService.java
@@ -1,5 +1,6 @@
 package jaega.homecare.domain.WorkLog.service.query;
 
+import jaega.homecare.domain.WorkLog.dto.res.GetDashboardSettlementResponse;
 import jaega.homecare.domain.WorkLog.dto.res.GetWorkLogByPaid;
 import jaega.homecare.domain.WorkLog.dto.res.GetWorkLogResponse;
 import jaega.homecare.domain.WorkLog.dto.res.GetWorkLogByDateResponse;
@@ -7,10 +8,13 @@ import jaega.homecare.domain.WorkLog.entity.WorkLog;
 import jaega.homecare.domain.WorkLog.mapper.WorkLogMapper;
 import jaega.homecare.domain.WorkLog.repository.WorkLogQueryRepository;
 import jaega.homecare.domain.WorkLog.repository.WorkLogRepository;
+import jaega.homecare.domain.center.entity.Center;
+import jaega.homecare.domain.center.service.query.CenterQueryService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
@@ -21,6 +25,7 @@ public class WorkLogQueryService {
     private final WorkLogRepository workLogRepository;
     private final WorkLogMapper workLogMapper;
     private final WorkLogQueryRepository workLogQueryRepository;
+    private final CenterQueryService centerQueryService;
 
     // 엔티티 조회용
     public WorkLog getWorkLog(UUID workLogId){
@@ -42,5 +47,22 @@ public class WorkLogQueryService {
 
     public List<GetWorkLogByPaid> getWorkLogByPaid(UUID centerId, Boolean isPaid){
         return workLogQueryRepository.findWorkLogsByPaid(centerId, isPaid);
+    }
+
+    public GetDashboardSettlementResponse getSettlementStatus(UUID centerId) {
+
+        BigDecimal totalSettledAmount = workLogQueryRepository.getTotalSettledAmountThisMonth(centerId);
+        if (totalSettledAmount == null) {
+            totalSettledAmount = BigDecimal.ZERO;
+        }
+        Long unsettledCount = workLogQueryRepository.countUnsettled(centerId);
+        if (unsettledCount == null) {
+            unsettledCount = 0L;
+        }
+
+        // TODO: 부정행위 알림 건수 조회 메서드 추가 시 적용할 것!
+        Long fraudAlertsCount = 0L;
+
+        return new GetDashboardSettlementResponse(totalSettledAmount, unsettledCount, fraudAlertsCount);
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/controller/WorkMatchController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/controller/WorkMatchController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import java.util.List;
 import java.util.UUID;
 
-@Tag(name = "WorkMatch", description = "정산 내역 일자 관련 조회 API")
+@Tag(name = "WorkMatch", description = "근무 내역 일자 관련 조회 API")
 @RequestMapping("/api/workMatch")
 public interface WorkMatchController {
 

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/controller/WorkMatchController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/controller/WorkMatchController.java
@@ -4,10 +4,7 @@ package jaega.homecare.domain.WorkMatch.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverWorkResponse;
-import jaega.homecare.domain.WorkMatch.dto.res.GetDailyUnsettledResponse;
-import jaega.homecare.domain.WorkMatch.dto.res.GetMonthlyPaymentResponse;
-import jaega.homecare.domain.WorkMatch.dto.res.GetSettlementSummaryResponse;
+import jaega.homecare.domain.WorkMatch.dto.res.*;
 import jaega.homecare.domain.WorkMatch.entity.WorkStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -45,5 +42,12 @@ public interface WorkMatchController {
     @Operation(summary = "센터의 정산 금액 및 정산 상태 통계 조회", description = "센터의 정산 금액 및 정산 상태 통계를 조회합니다.")
     @ApiResponse(responseCode = "200", description = "센터의 정산 금액, 상태 통계 조회 성공")
     @GetMapping("/settlementSummary")
-    GetSettlementSummaryResponse getSettlementSummary(@RequestParam UUID centerId);
+    GetSettlementCenterSummaryResponse getSettlementSummary(@RequestParam UUID centerId);
+
+    @Operation(summary = "센터의 요양보호사 정산 금액 및 정산 상태 통계 조회", description = "센터의 요양보호사 정산 금액 및 정산 상태 통계 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "센터의 요양보호사 정산 금액 및 정산 상태 통계 조회 성공")
+    @GetMapping("/caregiver/{caregiverId}/settlementSummary")
+    ResponseEntity<GetCaregiverSettlementSummaryResponse> getCaregiverSettlementSummary(
+            @PathVariable UUID caregiverId
+    );
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/controller/WorkMatchController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/controller/WorkMatchController.java
@@ -15,18 +15,28 @@ import org.springframework.web.bind.annotation.RequestParam;
 import java.util.List;
 import java.util.UUID;
 
-@Tag(name = "WorkMatch", description = "근무 일자 관련 조회 API")
+@Tag(name = "WorkMatch", description = "정산 내역 일자 관련 조회 API")
 @RequestMapping("/api/workMatch")
 public interface WorkMatchController {
 
-    @Operation(summary = "정산 페이지 요양 보호사 내역 조회 ", description = "정산 페이지의 요양 보호사 내역들을 조회합니다.")
-    @ApiResponse(responseCode = "204", description = "수요자가 서비스 요청 성공")
+    @Operation(summary = "센터의 요양 보호사 정산 내역 조회", description = "센터에 등록된 요양 보호사들의 정산 내역을 조회합니다.")
+    @ApiResponse(responseCode = "204", description = "센터에 등록된 요양 보호사들의 정산 내역을 조회 성공")
     @GetMapping(("/{centerId}/caregivers/work"))
     ResponseEntity<List<GetCaregiverWorkResponse>> getCaregiverWorkList(
             @PathVariable UUID centerId,
             @RequestParam(required = false) WorkStatus status,
-            @RequestParam(required = false) int year,
-            @RequestParam(required = false) int month
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) Integer month
+    );
+
+    @Operation(summary = "센터의 요양 보호사 개별 정산 내역 조회", description = "센터의 요양 보호사 개별 정산 내역 조회합니다.")
+    @ApiResponse(responseCode = "204", description = "센터의 요양 보호사 개별 정산 내역 조회 성공")
+    @GetMapping(("/{caregiverId}/work"))
+    ResponseEntity<List<GetCaregiverWorkResponse>> getCaregiverWorkListByCaregiver(
+            @PathVariable UUID caregiverId,
+            @RequestParam(required = false) WorkStatus status,
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) Integer month
     );
 
     @Operation(summary = "센터별 최근 6개월 총 정산 금액 조회", description = "센터의 최근 6개월 간 총 정산 금액을 조회합니다.")

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/controller/WorkMatchController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/controller/WorkMatchController.java
@@ -1,0 +1,31 @@
+package jaega.homecare.domain.WorkMatch.controller;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverWorkResponse;
+import jaega.homecare.domain.WorkMatch.entity.WorkStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+import java.util.UUID;
+
+@Tag(name = "WorkMatch", description = "근무 일자 관련 조회 API")
+@RequestMapping("/api/workMatch")
+public interface WorkMatchController {
+
+    @Operation(summary = "정산 페이지 요양 보호사 내역 조회 ", description = "정산 페이지의 요양 보호사 내역들을 조회합니다.")
+    @ApiResponse(responseCode = "204", description = "수요자가 서비스 요청 성공")
+    @GetMapping(("/{centerId}/caregivers/work"))
+    ResponseEntity<List<GetCaregiverWorkResponse>> getCaregiverWorkList(
+            @PathVariable UUID centerId,
+            @RequestParam(required = false) WorkStatus status,
+            @RequestParam int year,
+            @RequestParam int month
+    );
+}

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/controller/WorkMatchController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/controller/WorkMatchController.java
@@ -5,6 +5,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverWorkResponse;
+import jaega.homecare.domain.WorkMatch.dto.res.GetDailyUnsettledResponse;
+import jaega.homecare.domain.WorkMatch.dto.res.GetMonthlyPaymentResponse;
+import jaega.homecare.domain.WorkMatch.dto.res.GetSettlementSummaryResponse;
 import jaega.homecare.domain.WorkMatch.entity.WorkStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,7 +28,22 @@ public interface WorkMatchController {
     ResponseEntity<List<GetCaregiverWorkResponse>> getCaregiverWorkList(
             @PathVariable UUID centerId,
             @RequestParam(required = false) WorkStatus status,
-            @RequestParam int year,
-            @RequestParam int month
+            @RequestParam(required = false) int year,
+            @RequestParam(required = false) int month
     );
+
+    @Operation(summary = "센터별 최근 6개월 총 정산 금액 조회", description = "센터의 최근 6개월 간 총 정산 금액을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "센터의 6개월 간 총 정산 금액 조회 성공")
+    @GetMapping("/monthly")
+    List<GetMonthlyPaymentResponse> getMonthlyPaid(@RequestParam UUID centerId);
+
+    @Operation(summary = "센터별 최근 일주일 간 미정산 된 건수 조회", description = "센터의 최근 일주일 간 미정산 된 건수를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "센터의 일주일 간 미정산 건 조회 성공")
+    @GetMapping("/daily")
+    List<GetDailyUnsettledResponse> getDailyUnsettled(@RequestParam UUID centerId);
+
+    @Operation(summary = "센터의 정산 금액 및 정산 상태 통계 조회", description = "센터의 정산 금액 및 정산 상태 통계를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "센터의 정산 금액, 상태 통계 조회 성공")
+    @GetMapping("/settlementSummary")
+    GetSettlementSummaryResponse getSettlementSummary(@RequestParam UUID centerId);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/controller/WorkMatchControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/controller/WorkMatchControllerImpl.java
@@ -1,9 +1,6 @@
 package jaega.homecare.domain.WorkMatch.controller;
 
-import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverWorkResponse;
-import jaega.homecare.domain.WorkMatch.dto.res.GetDailyUnsettledResponse;
-import jaega.homecare.domain.WorkMatch.dto.res.GetMonthlyPaymentResponse;
-import jaega.homecare.domain.WorkMatch.dto.res.GetSettlementSummaryResponse;
+import jaega.homecare.domain.WorkMatch.dto.res.*;
 import jaega.homecare.domain.WorkMatch.entity.WorkStatus;
 import jaega.homecare.domain.WorkMatch.service.query.WorkMatchQueryService;
 import lombok.RequiredArgsConstructor;
@@ -50,7 +47,14 @@ public class WorkMatchControllerImpl implements WorkMatchController{
     }
 
     @Override
-    public GetSettlementSummaryResponse getSettlementSummary(@RequestParam UUID centerId) {
+    public GetSettlementCenterSummaryResponse getSettlementSummary(@RequestParam UUID centerId) {
         return workMatchQueryService.getSettlementSummary(centerId);
+    }
+
+    @Override
+    public ResponseEntity<GetCaregiverSettlementSummaryResponse> getCaregiverSettlementSummary(
+            @PathVariable UUID caregiverId
+    ) {
+        return ResponseEntity.ok(workMatchQueryService.getCaregiverSettlementSummary(caregiverId));
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/controller/WorkMatchControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/controller/WorkMatchControllerImpl.java
@@ -1,0 +1,38 @@
+package jaega.homecare.domain.WorkMatch.controller;
+
+import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverWorkResponse;
+import jaega.homecare.domain.WorkMatch.entity.WorkStatus;
+import jaega.homecare.domain.WorkMatch.service.query.WorkMatchQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/workMatch")
+public class WorkMatchControllerImpl implements WorkMatchController{
+    private final WorkMatchQueryService workMatchQueryService;
+
+
+    // 정산 페이지
+
+    /**
+     * 센터에 해당하는 요양보호사 근무 현황 조회
+     */
+    @Override
+    public ResponseEntity<List<GetCaregiverWorkResponse>> getCaregiverWorkList(
+            @PathVariable UUID centerId,
+            @RequestParam(required = false) WorkStatus status,
+            @RequestParam int year,
+            @RequestParam int month
+    ) {
+        List<GetCaregiverWorkResponse> result = workMatchQueryService.getCaregiverWorkList(centerId, status, year, month);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/controller/WorkMatchControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/controller/WorkMatchControllerImpl.java
@@ -1,6 +1,9 @@
 package jaega.homecare.domain.WorkMatch.controller;
 
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverWorkResponse;
+import jaega.homecare.domain.WorkMatch.dto.res.GetDailyUnsettledResponse;
+import jaega.homecare.domain.WorkMatch.dto.res.GetMonthlyPaymentResponse;
+import jaega.homecare.domain.WorkMatch.dto.res.GetSettlementSummaryResponse;
 import jaega.homecare.domain.WorkMatch.entity.WorkStatus;
 import jaega.homecare.domain.WorkMatch.service.query.WorkMatchQueryService;
 import lombok.RequiredArgsConstructor;
@@ -29,10 +32,25 @@ public class WorkMatchControllerImpl implements WorkMatchController{
     public ResponseEntity<List<GetCaregiverWorkResponse>> getCaregiverWorkList(
             @PathVariable UUID centerId,
             @RequestParam(required = false) WorkStatus status,
-            @RequestParam int year,
-            @RequestParam int month
+            @RequestParam(required = false) int year,
+            @RequestParam(required = false) int month
     ) {
         List<GetCaregiverWorkResponse> result = workMatchQueryService.getCaregiverWorkList(centerId, status, year, month);
         return ResponseEntity.ok(result);
+    }
+
+    @Override
+    public List<GetMonthlyPaymentResponse> getMonthlyPaid(@RequestParam UUID centerId) {
+        return workMatchQueryService.getMonthlyPaidSettlements(centerId);
+    }
+
+    @Override
+    public List<GetDailyUnsettledResponse> getDailyUnsettled(@RequestParam UUID centerId) {
+        return workMatchQueryService.getDailyUnsettledCount(centerId);
+    }
+
+    @Override
+    public GetSettlementSummaryResponse getSettlementSummary(@RequestParam UUID centerId) {
+        return workMatchQueryService.getSettlementSummary(centerId);
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/controller/WorkMatchControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/controller/WorkMatchControllerImpl.java
@@ -29,10 +29,21 @@ public class WorkMatchControllerImpl implements WorkMatchController{
     public ResponseEntity<List<GetCaregiverWorkResponse>> getCaregiverWorkList(
             @PathVariable UUID centerId,
             @RequestParam(required = false) WorkStatus status,
-            @RequestParam(required = false) int year,
-            @RequestParam(required = false) int month
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) Integer month
     ) {
         List<GetCaregiverWorkResponse> result = workMatchQueryService.getCaregiverWorkList(centerId, status, year, month);
+        return ResponseEntity.ok(result);
+    }
+
+    @Override
+    public ResponseEntity<List<GetCaregiverWorkResponse>> getCaregiverWorkListByCaregiver(
+            @PathVariable UUID caregiverId,
+            @RequestParam(required = false) WorkStatus status,
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) Integer month
+    ) {
+        List<GetCaregiverWorkResponse> result = workMatchQueryService.getCaregiverWorkListByCaregiver(caregiverId, status, year, month);
         return ResponseEntity.ok(result);
     }
 

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetCaregiverSettlementSummaryResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetCaregiverSettlementSummaryResponse.java
@@ -2,9 +2,10 @@ package jaega.homecare.domain.WorkMatch.dto.res;
 
 import java.math.BigDecimal;
 
-public record GetSettlementSummaryResponse(
+public record GetCaregiverSettlementSummaryResponse(
         BigDecimal totalAmount,
         Long completedCount,
-        Long pendingCount,
-        Long rejectedCount
-) {}
+        Long plannedCount,
+        Long cancelledCount
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetCaregiverWorkResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetCaregiverWorkResponse.java
@@ -1,0 +1,16 @@
+package jaega.homecare.domain.WorkMatch.dto.res;
+
+import jaega.homecare.domain.WorkMatch.entity.WorkStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record GetCaregiverWorkResponse (
+        String caregiverName,
+        LocalDate workDate,
+        LocalTime workStart,
+        LocalTime workEnd,
+        BigDecimal settlementAmount,
+        WorkStatus status
+) {}

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetDailyUnsettledResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetDailyUnsettledResponse.java
@@ -1,0 +1,9 @@
+package jaega.homecare.domain.WorkMatch.dto.res;
+
+import java.time.LocalDate;
+
+public record GetDailyUnsettledResponse(
+        LocalDate date,
+        Long count
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetDailyUnsettledResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetDailyUnsettledResponse.java
@@ -1,9 +1,11 @@
 package jaega.homecare.domain.WorkMatch.dto.res;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record GetDailyUnsettledResponse(
         LocalDate date,
-        Long count
+        Long count,
+        BigDecimal totalAmount  // 해당 일 미정산 금액
 ) {
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetDashboardWorkStatusResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetDashboardWorkStatusResponse.java
@@ -3,8 +3,8 @@ package jaega.homecare.domain.WorkMatch.dto.res;
 import java.util.List;
 
 public record GetDashboardWorkStatusResponse(
-        long workingToday,               // 오늘 근무자
-        long unassignedCaregivers,       // 미배정 보호사
-        long waitingApplicants,          // 신청자(배정 대기)
+        Long workingToday,               // 오늘 근무자
+        Long unassignedCaregivers,       // 미배정 보호사
+        Long waitingApplicants,          // 신청자(배정 대기)
         List<WorkPlaceDistribution> distribution // 근무지별 분포
 ) {}

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetDashboardWorkStatusResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetDashboardWorkStatusResponse.java
@@ -1,0 +1,10 @@
+package jaega.homecare.domain.WorkMatch.dto.res;
+
+import java.util.List;
+
+public record GetDashboardWorkStatusResponse(
+        long workingToday,               // 오늘 근무자
+        long unassignedCaregivers,       // 미배정 보호사
+        long waitingApplicants,          // 신청자(배정 대기)
+        List<WorkPlaceDistribution> distribution // 근무지별 분포
+) {}

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetMonthlyPaymentResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetMonthlyPaymentResponse.java
@@ -1,0 +1,10 @@
+package jaega.homecare.domain.WorkMatch.dto.res;
+
+import java.math.BigDecimal;
+
+public record GetMonthlyPaymentResponse(
+        int year,
+        int month,
+        BigDecimal totalAmount
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetSettlementCenterSummaryResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetSettlementCenterSummaryResponse.java
@@ -1,0 +1,10 @@
+package jaega.homecare.domain.WorkMatch.dto.res;
+
+import java.math.BigDecimal;
+
+public record GetSettlementCenterSummaryResponse(
+        BigDecimal totalAmount,
+        Long completedCount,
+        Long pendingCount,
+        Long rejectedCount
+) {}

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetSettlementSummaryResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/GetSettlementSummaryResponse.java
@@ -1,0 +1,10 @@
+package jaega.homecare.domain.WorkMatch.dto.res;
+
+import java.math.BigDecimal;
+
+public record GetSettlementSummaryResponse(
+        BigDecimal totalAmount,
+        Long completedCount,
+        Long pendingCount,
+        Long rejectedCount
+) {}

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/WorkPlaceDistribution.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/dto/res/WorkPlaceDistribution.java
@@ -1,0 +1,9 @@
+package jaega.homecare.domain.WorkMatch.dto.res;
+
+import jaega.homecare.domain.users.entity.ServiceType;
+
+public record WorkPlaceDistribution (
+        ServiceType serviceType,
+        Long count,
+        Double percent
+) {}

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/entity/WorkMatch.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/entity/WorkMatch.java
@@ -1,6 +1,7 @@
 package jaega.homecare.domain.WorkMatch.entity;
 
 import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.global.audit.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +15,7 @@ import java.util.UUID;
 @Getter
 @Table(name = "workMatch")
 @NoArgsConstructor
-public class WorkMatch {
+public class WorkMatch extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/entity/WorkMatch.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/entity/WorkMatch.java
@@ -53,6 +53,10 @@ public class WorkMatch extends BaseTimeEntity {
         this.status = WorkStatus.PLANNED;
     }
 
+    public void changeWorkStatus(WorkStatus workStatus){
+        this.status = workStatus;
+    }
+
     public void setWorkMatch(UUID workMatchId){
         this.workMatchId = workMatchId;
     }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
@@ -1,10 +1,13 @@
 package jaega.homecare.domain.WorkMatch.repository;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jaega.homecare.domain.WorkLog.entity.QWorkLog;
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesByMonth;
+import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverWorkResponse;
 import jaega.homecare.domain.WorkMatch.dto.res.WorkPlaceDistribution;
 import jaega.homecare.domain.WorkMatch.entity.QWorkMatch;
 import jaega.homecare.domain.WorkMatch.entity.WorkMatch;
@@ -223,4 +226,55 @@ public class WorkMatchQueryRepository {
                 .toList();
     }
 
+    // 정산 페이지
+
+    public List<GetCaregiverWorkResponse> getCaregiverWorkList(
+            UUID centerId,
+            WorkStatus status,   // nullable
+            Integer year,        // nullable
+            Integer month        // nullable
+    ) {
+        QWorkMatch workMatch = QWorkMatch.workMatch;
+        QWorkLog workLog = QWorkLog.workLog;
+        QCaregiver caregiver = QCaregiver.caregiver;
+        QUser user = QUser.user;
+
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(caregiver.center.centerId.eq(centerId));
+
+        // 상태 필터
+        if (status != null) {
+            where.and(workMatch.status.eq(status));
+        }
+
+        // 연/월 필터
+        if (year != null && month != null) {
+            where.and(workMatch.workDate.year().eq(year)
+                    .and(workMatch.workDate.month().eq(month)));
+        }
+
+        return queryFactory
+                .select(Projections.constructor(
+                        GetCaregiverWorkResponse.class,
+                        user.name,
+                        workMatch.workDate,
+                        workLog.workTime_start,
+                        workLog.workTime_end,
+                        workLog.settlementAmount,
+                        workMatch.status
+                ))
+                .from(workMatch)
+                .join(workMatch.caregiver, caregiver)
+                .join(caregiver.user, user)
+                .leftJoin(workLog).on(workLog.workMatch.eq(workMatch))
+                .where(where)
+                .orderBy(
+                        workLog.modifiedAt
+                                .coalesce(workLog.createdAt)
+                                .coalesce(workMatch.modifiedAt)
+                                .coalesce(workMatch.createdAt)
+                                .desc()
+                )
+                .fetch();
+    }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
@@ -227,7 +227,7 @@ public class WorkMatchQueryRepository {
 
     // 정산 페이지
 
-    public GetSettlementSummaryResponse getSettlementSummary(UUID centerId) {
+    public GetSettlementCenterSummaryResponse getSettlementSummary(UUID centerId) {
         QWorkLog workLog = QWorkLog.workLog;
         QWorkMatch workMatch = QWorkMatch.workMatch;
         QCaregiver caregiver = QCaregiver.caregiver;
@@ -265,7 +265,7 @@ public class WorkMatchQueryRepository {
             }
         }
 
-        return new GetSettlementSummaryResponse(
+        return new GetSettlementCenterSummaryResponse(
                 totalAmount,
                 completedCount,
                 plannedCount,
@@ -397,5 +397,66 @@ public class WorkMatchQueryRepository {
                 .groupBy(workMatch.workDate)
                 .orderBy(workMatch.workDate.desc())
                 .fetch();
+    }
+
+    // 요양보호사 정산 내역 요약 조회
+    public GetCaregiverSettlementSummaryResponse getCaregiverSettlementSummary(UUID caregiverId) {
+        QWorkMatch workMatch = QWorkMatch.workMatch;
+        QWorkLog workLog = QWorkLog.workLog;
+
+        // 총 정산 금액 (isPaid = true만)
+        BigDecimal totalAmount = Optional.ofNullable(
+                queryFactory
+                        .select(workLog.settlementAmount.sum())
+                        .from(workLog)
+                        .join(workLog.workMatch, workMatch)
+                        .where(
+                                workMatch.caregiver.caregiverId.eq(caregiverId),
+                                workMatch.status.eq(WorkStatus.COMPLETED),
+                                workLog.isPaid.eq(true)
+                        )
+                        .fetchOne()
+        ).orElse(BigDecimal.ZERO);
+
+        // 상태별 카운트
+        long completedCount = Optional.ofNullable(
+                queryFactory
+                        .select(workMatch.count())
+                        .from(workMatch)
+                        .where(
+                                workMatch.caregiver.caregiverId.eq(caregiverId),
+                                workMatch.status.eq(WorkStatus.COMPLETED)
+                        )
+                        .fetchOne()
+        ).orElse(0L);
+
+        long plannedCount = Optional.ofNullable(
+                queryFactory
+                        .select(workMatch.count())
+                        .from(workMatch)
+                        .where(
+                                workMatch.caregiver.caregiverId.eq(caregiverId),
+                                workMatch.status.eq(WorkStatus.PLANNED)
+                        )
+                        .fetchOne()
+        ).orElse(0L);
+
+        long cancelledCount = Optional.ofNullable(
+                queryFactory
+                        .select(workMatch.count())
+                        .from(workMatch)
+                        .where(
+                                workMatch.caregiver.caregiverId.eq(caregiverId),
+                                workMatch.status.eq(WorkStatus.CANCELLED)
+                        )
+                        .fetchOne()
+        ).orElse(0L);
+
+        return new GetCaregiverSettlementSummaryResponse(
+                totalAmount,
+                completedCount,
+                plannedCount,
+                cancelledCount
+        );
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
@@ -11,9 +11,9 @@ import jaega.homecare.domain.WorkMatch.entity.QWorkMatch;
 import jaega.homecare.domain.WorkMatch.entity.WorkMatch;
 import jaega.homecare.domain.WorkMatch.entity.WorkStatus;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
-import jaega.homecare.domain.caregiver.entity.CaregiverStatus;
 import jaega.homecare.domain.caregiver.entity.QCaregiver;
 import jaega.homecare.domain.caregiver.repository.CaregiverRepository;
+import jaega.homecare.domain.caregiverCenter.entity.CaregiverStatus;
 import jaega.homecare.domain.caregiverCenter.entity.QCaregiverCenter;
 import jaega.homecare.domain.users.entity.QUser;
 import jaega.homecare.domain.users.entity.ServiceType;
@@ -67,7 +67,7 @@ public class WorkMatchQueryRepository {
                 .from(workMatch)
                 .join(workMatch.caregiver, caregiver)
                 .join(caregiver.user, user)
-                .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))  // 필터용 join 추가
+                .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
                 .where(
                         workMatch.workDate.between(startDate, endDate),
                         caregiverCenter.center.centerId.eq(centerId)
@@ -139,6 +139,7 @@ public class WorkMatchQueryRepository {
     public Long countCaregiversWorkingToday(UUID centerId) {
         QWorkMatch workMatch = QWorkMatch.workMatch;
         QCaregiver caregiver = QCaregiver.caregiver;
+        QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
 
         LocalDate today = LocalDate.now();
 
@@ -146,9 +147,10 @@ public class WorkMatchQueryRepository {
                 .select(workMatch.caregiver.countDistinct())
                 .from(workMatch)
                 .join(workMatch.caregiver, caregiver)
+                .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
                 .where(
-                        workMatch.workDate.eq(today.plusDays(1))
-                                .and(caregiver.center.centerId.eq(centerId))
+                        caregiverCenter.center.centerId.eq(centerId)
+                                .and(workMatch.workDate.eq(today))
                                 .and(workMatch.status.in(WorkStatus.PLANNED, WorkStatus.COMPLETED))
                 )
                 .fetchOne();
@@ -158,13 +160,16 @@ public class WorkMatchQueryRepository {
     public Long countUnassignedCaregiversToday(UUID centerId) {
         QCaregiver caregiver = QCaregiver.caregiver;
         QWorkMatch workMatch = QWorkMatch.workMatch;
+        QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
 
         LocalDate today = LocalDate.now();
 
-        // 서브쿼리: 오늘 배정된 caregiverId
+        // 오늘 배정된 caregiverId 서브쿼리
         List<UUID> assignedCaregiverIds = queryFactory
                 .select(workMatch.caregiver.caregiverId)
                 .from(workMatch)
+                .join(workMatch.caregiver, caregiver)
+                .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
                 .where(workMatch.workDate.eq(today))
                 .fetch();
 
@@ -172,8 +177,9 @@ public class WorkMatchQueryRepository {
         return queryFactory
                 .select(caregiver.count())
                 .from(caregiver)
+                .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
                 .where(
-                        caregiver.center.centerId.eq(centerId)
+                        caregiverCenter.center.centerId.eq(centerId)
                                 .and(caregiver.caregiverId.notIn(assignedCaregiverIds))
                 )
                 .fetchOne();
@@ -183,16 +189,22 @@ public class WorkMatchQueryRepository {
     public Long countWaitingApplicants(UUID centerId) {
         QWorkMatch workMatch = QWorkMatch.workMatch;
         QCaregiver caregiver = QCaregiver.caregiver;
+        QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
+
+        LocalDate today = LocalDate.now();
 
         return queryFactory
                 .select(workMatch.count())
                 .from(workMatch)
                 .leftJoin(workMatch.caregiver, caregiver)
+                .leftJoin(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
                 .where(
                         workMatch.status.eq(WorkStatus.PLANNED)
-                                .and(workMatch.caregiver.isNull())
-                                .and(workMatch.workDate.eq(LocalDate.now()))
-                                .and(workMatch.caregiver.center.centerId.eq(centerId).or(workMatch.caregiver.isNull())) // caregiver 없으면 center 조건 제외 가능
+                                .and(workMatch.workDate.eq(today))
+                                .and(
+                                        workMatch.caregiver.isNull()
+                                                .or(caregiverCenter.center.centerId.eq(centerId))
+                                )
                 )
                 .fetchOne();
     }
@@ -200,36 +212,38 @@ public class WorkMatchQueryRepository {
     // 요양 보호사 대시보드의 근무지 별 분포 통계 조회
     public List<WorkPlaceDistribution> getWorkPlaceDistributionByServiceType(UUID centerId) {
         QCaregiver caregiver = QCaregiver.caregiver;
+        QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
 
-        // 1. centerId에 속한 보호사 ID 리스트 가져오기
-        List<Long> caregiverIds = queryFactory
-                .select(caregiver.id)
+        // center 소속 활성 보호사 + serviceTypes 조회
+        List<Tuple> rows = queryFactory
+                .select(caregiver, caregiver.serviceTypes)
                 .from(caregiver)
+                .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
                 .where(
-                        caregiver.center.centerId.eq(centerId),
-                        caregiver.status.eq(CaregiverStatus.ACTIVE)
+                        caregiverCenter.center.centerId.eq(centerId),
+                        caregiverCenter.status.eq(CaregiverStatus.ACTIVE)
                 )
                 .fetch();
 
-        if (caregiverIds.isEmpty()) {
+        if (rows.isEmpty()) {
             return Collections.emptyList();
         }
 
-        // 2. JPQL로 serviceTypes 조회
-        List<Object[]> rows = caregiverRepository.findServiceTypesByIds(new HashSet<>(caregiverIds));
-        // rows = [ [caregiverId, ServiceType], [caregiverId, ServiceType], ... ]
-
-        // 3. ServiceType별 카운트 계산
+        // ServiceType별 카운트 계산
         Map<ServiceType, Long> serviceTypeCount = new HashMap<>();
-        for (Object[] row : rows) {
-            ServiceType st = (ServiceType) row[1];
-            serviceTypeCount.put(st, serviceTypeCount.getOrDefault(st, 0L) + 1);
+        for (Tuple row : rows) {
+            Set<ServiceType> serviceTypes = row.get(caregiver.serviceTypes);
+            if (serviceTypes != null) {
+                for (ServiceType st : serviceTypes) {
+                    serviceTypeCount.put(st, serviceTypeCount.getOrDefault(st, 0L) + 1);
+                }
+            }
         }
 
-        // 4. 총합 계산
+        // 총합 계산
         long total = serviceTypeCount.values().stream().mapToLong(Long::longValue).sum();
 
-        // 5. DTO 변환
+        // DTO 변환
         return serviceTypeCount.entrySet().stream()
                 .map(entry -> new WorkPlaceDistribution(
                         entry.getKey(),
@@ -246,6 +260,7 @@ public class WorkMatchQueryRepository {
         QWorkLog workLog = QWorkLog.workLog;
         QWorkMatch workMatch = QWorkMatch.workMatch;
         QCaregiver caregiver = QCaregiver.caregiver;
+        QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
 
         List<Tuple> results = queryFactory
                 .select(
@@ -255,8 +270,9 @@ public class WorkMatchQueryRepository {
                 )
                 .from(workMatch)
                 .join(workMatch.caregiver, caregiver)
+                .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
                 .leftJoin(workLog).on(workLog.workMatch.eq(workMatch))
-                .where(caregiver.center.centerId.eq(centerId))
+                .where(caregiverCenter.center.centerId.eq(centerId))
                 .groupBy(workMatch.status)
                 .fetch();
 
@@ -359,10 +375,11 @@ public class WorkMatchQueryRepository {
         QWorkMatch workMatch = QWorkMatch.workMatch;
         QWorkLog workLog = QWorkLog.workLog;
         QCaregiver caregiver = QCaregiver.caregiver;
+        QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
         QUser user = QUser.user;
 
         BooleanBuilder where = new BooleanBuilder();
-        where.and(caregiver.center.centerId.eq(centerId));
+        where.and(caregiverCenter.center.centerId.eq(centerId));
 
         // 상태 필터
         if (status != null) {
@@ -390,6 +407,7 @@ public class WorkMatchQueryRepository {
                 .from(workMatch)
                 .join(workMatch.caregiver, caregiver)
                 .join(caregiver.user, user)
+                .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
                 .leftJoin(workLog).on(workLog.workMatch.eq(workMatch))
                 .where(where)
                 .orderBy(
@@ -412,6 +430,7 @@ public class WorkMatchQueryRepository {
         QWorkMatch workMatch = QWorkMatch.workMatch;
         QWorkLog workLog = QWorkLog.workLog;
         QCaregiver caregiver = QCaregiver.caregiver;
+        QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
         QUser user = QUser.user;
 
         BooleanBuilder where = new BooleanBuilder();
@@ -441,6 +460,7 @@ public class WorkMatchQueryRepository {
                 .from(workMatch)
                 .join(workMatch.caregiver, caregiver)
                 .join(caregiver.user, user)
+                .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
                 .leftJoin(workLog).on(workLog.workMatch.eq(workMatch))
                 .where(where)
                 .orderBy(
@@ -458,6 +478,7 @@ public class WorkMatchQueryRepository {
         QWorkLog workLog = QWorkLog.workLog;
         QWorkMatch workMatch = QWorkMatch.workMatch;
         QCaregiver caregiver = QCaregiver.caregiver;
+        QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
 
         LocalDate now = LocalDate.now();
         LocalDate startMonth = now.minusMonths(monthsBack - 1).withDayOfMonth(1);
@@ -472,9 +493,10 @@ public class WorkMatchQueryRepository {
                 .from(workLog)
                 .join(workLog.workMatch, workMatch)
                 .join(workMatch.caregiver, caregiver)
+                .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
                 .where(workLog.isPaid.eq(true)
                         .and(workMatch.status.eq(WorkStatus.COMPLETED))
-                        .and(caregiver.center.centerId.eq(centerId))
+                        .and(caregiverCenter.center.centerId.eq(centerId))
                         .and(workMatch.workDate.goe(startMonth)))
                 .groupBy(workMatch.workDate.year(), workMatch.workDate.month())
                 .orderBy(workMatch.workDate.year().desc(), workMatch.workDate.month().desc())
@@ -506,6 +528,7 @@ public class WorkMatchQueryRepository {
         QWorkLog workLog = QWorkLog.workLog;
         QWorkMatch workMatch = QWorkMatch.workMatch;
         QCaregiver caregiver = QCaregiver.caregiver;
+        QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
 
         LocalDate startDate = LocalDate.now().minusDays(6); // 오늘 포함 최근 7일
 
@@ -519,9 +542,10 @@ public class WorkMatchQueryRepository {
                 .from(workLog)
                 .join(workLog.workMatch, workMatch)
                 .join(workMatch.caregiver, caregiver)
+                .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
                 .where(workLog.isPaid.eq(false)
                         .and(workMatch.status.ne(WorkStatus.COMPLETED))
-                        .and(caregiver.center.centerId.eq(centerId))
+                        .and(caregiverCenter.center.centerId.eq(centerId))
                         .and(workMatch.workDate.goe(startDate)))
                 .groupBy(workMatch.workDate)
                 .orderBy(workMatch.workDate.desc())

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
@@ -274,7 +274,6 @@ public class WorkMatchQueryRepository {
                 .leftJoin(workLog).on(workLog.workMatch.eq(workMatch))
                 .where(caregiverCenter.center.centerId.eq(centerId))
                 .groupBy(workMatch.status)
-                .orderBy(workMatch.createdAt.desc())
                 .fetch();
 
         BigDecimal totalAmount = BigDecimal.ZERO;
@@ -532,9 +531,10 @@ public class WorkMatchQueryRepository {
         QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
 
         LocalDate today = LocalDate.now();
-        LocalDate startDate = LocalDate.now().minusDays(6); // 오늘 포함 최근 7일
+        LocalDate startDate = today.minusDays(6); // 최근 7일
 
-        return queryFactory
+        // 실제 DB에서 미정산 내역 조회
+        List<GetDailyUnsettledResponse> rawResults = queryFactory
                 .select(Projections.constructor(
                         GetDailyUnsettledResponse.class,
                         workMatch.workDate,
@@ -551,7 +551,19 @@ public class WorkMatchQueryRepository {
                         .and(workMatch.workDate.between(startDate, today))
                 )
                 .groupBy(workMatch.workDate)
-                .orderBy(workMatch.workDate.year().desc(), workMatch.workDate.month().desc())
+                .orderBy(workMatch.workDate.asc())
                 .fetch();
+
+        // 누락된 날짜 채우기
+        Map<LocalDate, GetDailyUnsettledResponse> map = rawResults.stream()
+                .collect(Collectors.toMap(GetDailyUnsettledResponse::date, r -> r));
+
+        List<GetDailyUnsettledResponse> filled = new ArrayList<>();
+        for (int i = 0; i <= 6; i++) {
+            LocalDate date = startDate.plusDays(i);
+            filled.add(map.getOrDefault(date, new GetDailyUnsettledResponse(date, 0L, BigDecimal.ZERO)));
+        }
+
+        return filled;
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
@@ -6,9 +6,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jaega.homecare.domain.WorkLog.entity.QWorkLog;
-import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesByMonth;
-import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverWorkResponse;
-import jaega.homecare.domain.WorkMatch.dto.res.WorkPlaceDistribution;
+import jaega.homecare.domain.WorkMatch.dto.res.*;
 import jaega.homecare.domain.WorkMatch.entity.QWorkMatch;
 import jaega.homecare.domain.WorkMatch.entity.WorkMatch;
 import jaega.homecare.domain.WorkMatch.entity.WorkStatus;
@@ -21,6 +19,7 @@ import jaega.homecare.domain.users.entity.ServiceType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.*;
@@ -228,6 +227,52 @@ public class WorkMatchQueryRepository {
 
     // 정산 페이지
 
+    public GetSettlementSummaryResponse getSettlementSummary(UUID centerId) {
+        QWorkLog workLog = QWorkLog.workLog;
+        QWorkMatch workMatch = QWorkMatch.workMatch;
+        QCaregiver caregiver = QCaregiver.caregiver;
+
+        List<Tuple> results = queryFactory
+                .select(
+                        workMatch.status,
+                        workLog.settlementAmount.sum(),
+                        workMatch.count()
+                )
+                .from(workMatch)
+                .join(workMatch.caregiver, caregiver)
+                .leftJoin(workLog).on(workLog.workMatch.eq(workMatch))
+                .where(caregiver.center.centerId.eq(centerId))
+                .groupBy(workMatch.status)
+                .fetch();
+
+        BigDecimal totalAmount = BigDecimal.ZERO;
+        long completedCount = 0L;
+        long plannedCount = 0L;
+        long cancelledCount = 0L;
+
+        for (Tuple tuple : results) {
+            WorkStatus status = tuple.get(workMatch.status);
+            BigDecimal sumAmount = tuple.get(workLog.settlementAmount.sum());
+            Long count = tuple.get(workMatch.count());
+
+            if (status == WorkStatus.COMPLETED) {
+                completedCount = count;
+                totalAmount = totalAmount.add(sumAmount != null ? sumAmount : BigDecimal.ZERO);
+            } else if (status == WorkStatus.PLANNED) {
+                plannedCount = count;
+            } else if (status == WorkStatus.CANCELLED) {
+                cancelledCount = count;
+            }
+        }
+
+        return new GetSettlementSummaryResponse(
+                totalAmount,
+                completedCount,
+                plannedCount,
+                cancelledCount
+        );
+    }
+
     public List<GetCaregiverWorkResponse> getCaregiverWorkList(
             UUID centerId,
             WorkStatus status,   // nullable
@@ -245,6 +290,8 @@ public class WorkMatchQueryRepository {
         // 상태 필터
         if (status != null) {
             where.and(workMatch.status.eq(status));
+        } else {
+            where.and(workMatch.status.eq(WorkStatus.COMPLETED));
         }
 
         // 연/월 필터
@@ -275,6 +322,80 @@ public class WorkMatchQueryRepository {
                                 .coalesce(workMatch.createdAt)
                                 .desc()
                 )
+                .fetch();
+    }
+
+    // 이번 달 총 정산내역 조회
+    public List<GetMonthlyPaymentResponse> getMonthlyPaidSettlements(UUID centerId, int monthsBack) {
+        QWorkLog workLog = QWorkLog.workLog;
+        QWorkMatch workMatch = QWorkMatch.workMatch;
+        QCaregiver caregiver = QCaregiver.caregiver;
+
+        LocalDate now = LocalDate.now();
+        LocalDate startMonth = now.minusMonths(monthsBack - 1).withDayOfMonth(1);
+
+        List<GetMonthlyPaymentResponse> rawResults = queryFactory
+                .select(Projections.constructor(
+                        GetMonthlyPaymentResponse.class,
+                        workMatch.workDate.year(),
+                        workMatch.workDate.month(),
+                        workLog.settlementAmount.sum()
+                ))
+                .from(workLog)
+                .join(workLog.workMatch, workMatch)
+                .join(workMatch.caregiver, caregiver)
+                .where(workLog.isPaid.eq(true)
+                        .and(workMatch.status.eq(WorkStatus.COMPLETED))
+                        .and(caregiver.center.centerId.eq(centerId))
+                        .and(workMatch.workDate.goe(startMonth)))
+                .groupBy(workMatch.workDate.year(), workMatch.workDate.month())
+                .orderBy(workMatch.workDate.year().desc(), workMatch.workDate.month().desc())
+                .fetch();
+
+        // 누락된 월 채우기
+        Map<String, BigDecimal> map = rawResults.stream()
+                .collect(Collectors.toMap(
+                        r -> r.year() + "-" + r.month(),
+                        GetMonthlyPaymentResponse::totalAmount
+                ));
+
+        List<GetMonthlyPaymentResponse> filled = new ArrayList<>();
+        for (int i = 0; i < monthsBack; i++) {
+            LocalDate target = now.minusMonths(i);
+            String key = target.getYear() + "-" + target.getMonthValue();
+            filled.add(new GetMonthlyPaymentResponse(
+                    target.getYear(),
+                    target.getMonthValue(),
+                    map.getOrDefault(key, BigDecimal.ZERO)
+            ));
+        }
+
+        return filled;
+    }
+
+    // 일주일 간 미정산 내역 조회
+    public List<GetDailyUnsettledResponse> getDailyUnsettledCount(UUID centerId) {
+        QWorkLog workLog = QWorkLog.workLog;
+        QWorkMatch workMatch = QWorkMatch.workMatch;
+        QCaregiver caregiver = QCaregiver.caregiver;
+
+        LocalDate startDate = LocalDate.now().minusDays(6); // 오늘 포함 최근 7일
+
+        return queryFactory
+                .select(Projections.constructor(
+                        GetDailyUnsettledResponse.class,
+                        workMatch.workDate,
+                        workLog.count()
+                ))
+                .from(workLog)
+                .join(workLog.workMatch, workMatch)
+                .join(workMatch.caregiver, caregiver)
+                .where(workLog.isPaid.eq(false)
+                        .and(workMatch.status.ne(WorkStatus.COMPLETED))
+                        .and(caregiver.center.centerId.eq(centerId))
+                        .and(workMatch.workDate.goe(startDate)))
+                .groupBy(workMatch.workDate)
+                .orderBy(workMatch.workDate.desc())
                 .fetch();
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
@@ -31,6 +31,7 @@ public class WorkMatchQueryRepository {
     private final JPAQueryFactory queryFactory;
     private final CaregiverRepository caregiverRepository;
 
+    // 센터에 등록된 요양보호사 정산 내역 조회
     public List<GetCaregiverMatchesByMonth> findWorkMatchesByMonth(UUID centerId, int year, int month, Integer day) {
         QWorkMatch workMatch = QWorkMatch.workMatch;
         QCaregiver caregiver = QCaregiver.caregiver;
@@ -124,8 +125,11 @@ public class WorkMatchQueryRepository {
                 .fetch();
     }
 
-    // 대시보드를 위한 api
+    /**
+     * 대시보드의 통계를 위한 api
+     */
 
+    // 오늘 근무하는 요양보호사 수 조회
     public Long countCaregiversWorkingToday(UUID centerId) {
         QWorkMatch workMatch = QWorkMatch.workMatch;
         QCaregiver caregiver = QCaregiver.caregiver;
@@ -144,6 +148,7 @@ public class WorkMatchQueryRepository {
                 .fetchOne();
     }
 
+    // 오늚 미배정된 요양보호사 수 조회
     public Long countUnassignedCaregiversToday(UUID centerId) {
         QCaregiver caregiver = QCaregiver.caregiver;
         QWorkMatch workMatch = QWorkMatch.workMatch;
@@ -168,6 +173,7 @@ public class WorkMatchQueryRepository {
                 .fetchOne();
     }
 
+    // 배정 대기인 요양보호사 수 조회
     public Long countWaitingApplicants(UUID centerId) {
         QWorkMatch workMatch = QWorkMatch.workMatch;
         QCaregiver caregiver = QCaregiver.caregiver;
@@ -184,6 +190,8 @@ public class WorkMatchQueryRepository {
                 )
                 .fetchOne();
     }
+
+    // 요양 보호사 대시보드의 근무지 별 분포 통계 조회
     public List<WorkPlaceDistribution> getWorkPlaceDistributionByServiceType(UUID centerId) {
         QCaregiver caregiver = QCaregiver.caregiver;
 
@@ -227,7 +235,8 @@ public class WorkMatchQueryRepository {
 
     // 정산 페이지
 
-    public GetSettlementCenterSummaryResponse getSettlementSummary(UUID centerId) {
+    // 센터에 등록된 요양보호사 정산 금액, 건수 조회
+    public GetSettlementCenterSummaryResponse getSettlementCenterSummary(UUID centerId) {
         QWorkLog workLog = QWorkLog.workLog;
         QWorkMatch workMatch = QWorkMatch.workMatch;
         QCaregiver caregiver = QCaregiver.caregiver;
@@ -273,7 +282,69 @@ public class WorkMatchQueryRepository {
         );
     }
 
-    public List<GetCaregiverWorkResponse> getCaregiverWorkList(
+    // 요양보호사 개별 정산 금액, 건수 조회
+    public GetCaregiverSettlementSummaryResponse getCaregiverSettlementSummary(UUID caregiverId) {
+        QWorkMatch workMatch = QWorkMatch.workMatch;
+        QWorkLog workLog = QWorkLog.workLog;
+
+        // 총 정산 금액 (isPaid = true만)
+        BigDecimal totalAmount = Optional.ofNullable(
+                queryFactory
+                        .select(workLog.settlementAmount.sum())
+                        .from(workLog)
+                        .join(workLog.workMatch, workMatch)
+                        .where(
+                                workMatch.caregiver.caregiverId.eq(caregiverId),
+                                workMatch.status.eq(WorkStatus.COMPLETED),
+                                workLog.isPaid.eq(true)
+                        )
+                        .fetchOne()
+        ).orElse(BigDecimal.ZERO);
+
+        // 상태별 카운트
+        long completedCount = Optional.ofNullable(
+                queryFactory
+                        .select(workMatch.count())
+                        .from(workMatch)
+                        .where(
+                                workMatch.caregiver.caregiverId.eq(caregiverId),
+                                workMatch.status.eq(WorkStatus.COMPLETED)
+                        )
+                        .fetchOne()
+        ).orElse(0L);
+
+        long plannedCount = Optional.ofNullable(
+                queryFactory
+                        .select(workMatch.count())
+                        .from(workMatch)
+                        .where(
+                                workMatch.caregiver.caregiverId.eq(caregiverId),
+                                workMatch.status.eq(WorkStatus.PLANNED)
+                        )
+                        .fetchOne()
+        ).orElse(0L);
+
+        long cancelledCount = Optional.ofNullable(
+                queryFactory
+                        .select(workMatch.count())
+                        .from(workMatch)
+                        .where(
+                                workMatch.caregiver.caregiverId.eq(caregiverId),
+                                workMatch.status.eq(WorkStatus.CANCELLED)
+                        )
+                        .fetchOne()
+        ).orElse(0L);
+
+        return new GetCaregiverSettlementSummaryResponse(
+                totalAmount,
+                completedCount,
+                plannedCount,
+                cancelledCount
+        );
+    }
+
+    // 센터에 등록된 요양보호사의 근무 상태, 월-연도별 내역 조회
+    public List<GetCaregiverWorkResponse> getCaregiverWorkListByCenter(
             UUID centerId,
             WorkStatus status,   // nullable
             Integer year,        // nullable
@@ -292,6 +363,57 @@ public class WorkMatchQueryRepository {
             where.and(workMatch.status.eq(status));
         } else {
             where.and(workMatch.status.eq(WorkStatus.COMPLETED));
+        }
+
+        // 연/월 필터
+        if (year != null && month != null) {
+            where.and(workMatch.workDate.year().eq(year)
+                    .and(workMatch.workDate.month().eq(month)));
+        }
+
+        return queryFactory
+                .select(Projections.constructor(
+                        GetCaregiverWorkResponse.class,
+                        user.name,
+                        workMatch.workDate,
+                        workLog.workTime_start,
+                        workLog.workTime_end,
+                        workLog.settlementAmount,
+                        workMatch.status
+                ))
+                .from(workMatch)
+                .join(workMatch.caregiver, caregiver)
+                .join(caregiver.user, user)
+                .leftJoin(workLog).on(workLog.workMatch.eq(workMatch))
+                .where(where)
+                .orderBy(
+                        workLog.modifiedAt
+                                .coalesce(workLog.createdAt)
+                                .coalesce(workMatch.modifiedAt)
+                                .coalesce(workMatch.createdAt)
+                                .desc()
+                )
+                .fetch();
+    }
+
+    // 개별 요양보호사의 근무 상태, 월-연도별 내역 조회
+    public List<GetCaregiverWorkResponse> getCaregiverWorkListByCaregiver(
+            UUID caregiverId,
+            WorkStatus status,   // nullable
+            Integer year,        // nullable
+            Integer month        // nullable
+    ) {
+        QWorkMatch workMatch = QWorkMatch.workMatch;
+        QWorkLog workLog = QWorkLog.workLog;
+        QCaregiver caregiver = QCaregiver.caregiver;
+        QUser user = QUser.user;
+
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(caregiver.caregiverId.eq(caregiverId));
+
+        // 상태 필터
+        if (status != null) {
+            where.and(workMatch.status.eq(status));
         }
 
         // 연/월 필터
@@ -397,66 +519,5 @@ public class WorkMatchQueryRepository {
                 .groupBy(workMatch.workDate)
                 .orderBy(workMatch.workDate.desc())
                 .fetch();
-    }
-
-    // 요양보호사 정산 내역 요약 조회
-    public GetCaregiverSettlementSummaryResponse getCaregiverSettlementSummary(UUID caregiverId) {
-        QWorkMatch workMatch = QWorkMatch.workMatch;
-        QWorkLog workLog = QWorkLog.workLog;
-
-        // 총 정산 금액 (isPaid = true만)
-        BigDecimal totalAmount = Optional.ofNullable(
-                queryFactory
-                        .select(workLog.settlementAmount.sum())
-                        .from(workLog)
-                        .join(workLog.workMatch, workMatch)
-                        .where(
-                                workMatch.caregiver.caregiverId.eq(caregiverId),
-                                workMatch.status.eq(WorkStatus.COMPLETED),
-                                workLog.isPaid.eq(true)
-                        )
-                        .fetchOne()
-        ).orElse(BigDecimal.ZERO);
-
-        // 상태별 카운트
-        long completedCount = Optional.ofNullable(
-                queryFactory
-                        .select(workMatch.count())
-                        .from(workMatch)
-                        .where(
-                                workMatch.caregiver.caregiverId.eq(caregiverId),
-                                workMatch.status.eq(WorkStatus.COMPLETED)
-                        )
-                        .fetchOne()
-        ).orElse(0L);
-
-        long plannedCount = Optional.ofNullable(
-                queryFactory
-                        .select(workMatch.count())
-                        .from(workMatch)
-                        .where(
-                                workMatch.caregiver.caregiverId.eq(caregiverId),
-                                workMatch.status.eq(WorkStatus.PLANNED)
-                        )
-                        .fetchOne()
-        ).orElse(0L);
-
-        long cancelledCount = Optional.ofNullable(
-                queryFactory
-                        .select(workMatch.count())
-                        .from(workMatch)
-                        .where(
-                                workMatch.caregiver.caregiverId.eq(caregiverId),
-                                workMatch.status.eq(WorkStatus.CANCELLED)
-                        )
-                        .fetchOne()
-        ).orElse(0L);
-
-        return new GetCaregiverSettlementSummaryResponse(
-                totalAmount,
-                completedCount,
-                plannedCount,
-                cancelledCount
-        );
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
@@ -1,13 +1,16 @@
 package jaega.homecare.domain.WorkMatch.repository;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesByMonth;
+import jaega.homecare.domain.WorkMatch.dto.res.WorkPlaceDistribution;
 import jaega.homecare.domain.WorkMatch.entity.QWorkMatch;
 import jaega.homecare.domain.WorkMatch.entity.WorkMatch;
 import jaega.homecare.domain.WorkMatch.entity.WorkStatus;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.domain.caregiver.entity.CaregiverStatus;
 import jaega.homecare.domain.caregiver.entity.QCaregiver;
 import jaega.homecare.domain.caregiver.repository.CaregiverRepository;
 import jaega.homecare.domain.users.entity.QUser;
@@ -118,4 +121,106 @@ public class WorkMatchQueryRepository {
                 )
                 .fetch();
     }
+
+    // 대시보드를 위한 api
+
+    public Long countCaregiversWorkingToday(UUID centerId) {
+        QWorkMatch workMatch = QWorkMatch.workMatch;
+        QCaregiver caregiver = QCaregiver.caregiver;
+
+        LocalDate today = LocalDate.now();
+
+        return queryFactory
+                .select(workMatch.caregiver.countDistinct())
+                .from(workMatch)
+                .join(workMatch.caregiver, caregiver)
+                .where(
+                        workMatch.workDate.eq(today.plusDays(1))
+                                .and(caregiver.center.centerId.eq(centerId))
+                                .and(workMatch.status.in(WorkStatus.PLANNED, WorkStatus.COMPLETED))
+                )
+                .fetchOne();
+    }
+
+    public Long countUnassignedCaregiversToday(UUID centerId) {
+        QCaregiver caregiver = QCaregiver.caregiver;
+        QWorkMatch workMatch = QWorkMatch.workMatch;
+
+        LocalDate today = LocalDate.now();
+
+        // 서브쿼리: 오늘 배정된 caregiverId
+        List<UUID> assignedCaregiverIds = queryFactory
+                .select(workMatch.caregiver.caregiverId)
+                .from(workMatch)
+                .where(workMatch.workDate.eq(today))
+                .fetch();
+
+        // 전체 센터 소속 caregiver 중 오늘 미배정인 수
+        return queryFactory
+                .select(caregiver.count())
+                .from(caregiver)
+                .where(
+                        caregiver.center.centerId.eq(centerId)
+                                .and(caregiver.caregiverId.notIn(assignedCaregiverIds))
+                )
+                .fetchOne();
+    }
+
+    public Long countWaitingApplicants(UUID centerId) {
+        QWorkMatch workMatch = QWorkMatch.workMatch;
+        QCaregiver caregiver = QCaregiver.caregiver;
+
+        return queryFactory
+                .select(workMatch.count())
+                .from(workMatch)
+                .leftJoin(workMatch.caregiver, caregiver)
+                .where(
+                        workMatch.status.eq(WorkStatus.PLANNED)
+                                .and(workMatch.caregiver.isNull())
+                                .and(workMatch.workDate.eq(LocalDate.now()))
+                                .and(workMatch.caregiver.center.centerId.eq(centerId).or(workMatch.caregiver.isNull())) // caregiver 없으면 center 조건 제외 가능
+                )
+                .fetchOne();
+    }
+    public List<WorkPlaceDistribution> getWorkPlaceDistributionByServiceType(UUID centerId) {
+        QCaregiver caregiver = QCaregiver.caregiver;
+
+        // 1. centerId에 속한 보호사 ID 리스트 가져오기
+        List<Long> caregiverIds = queryFactory
+                .select(caregiver.id)
+                .from(caregiver)
+                .where(
+                        caregiver.center.centerId.eq(centerId),
+                        caregiver.status.eq(CaregiverStatus.ACTIVE)
+                )
+                .fetch();
+
+        if (caregiverIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // 2. JPQL로 serviceTypes 조회
+        List<Object[]> rows = caregiverRepository.findServiceTypesByIds(new HashSet<>(caregiverIds));
+        // rows = [ [caregiverId, ServiceType], [caregiverId, ServiceType], ... ]
+
+        // 3. ServiceType별 카운트 계산
+        Map<ServiceType, Long> serviceTypeCount = new HashMap<>();
+        for (Object[] row : rows) {
+            ServiceType st = (ServiceType) row[1];
+            serviceTypeCount.put(st, serviceTypeCount.getOrDefault(st, 0L) + 1);
+        }
+
+        // 4. 총합 계산
+        long total = serviceTypeCount.values().stream().mapToLong(Long::longValue).sum();
+
+        // 5. DTO 변환
+        return serviceTypeCount.entrySet().stream()
+                .map(entry -> new WorkPlaceDistribution(
+                        entry.getKey(),
+                        entry.getValue(),
+                        total > 0 ? (double) entry.getValue() * 100 / total : 0.0
+                ))
+                .toList();
+    }
+
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
@@ -507,7 +507,8 @@ public class WorkMatchQueryRepository {
                 .select(Projections.constructor(
                         GetDailyUnsettledResponse.class,
                         workMatch.workDate,
-                        workLog.count()
+                        workLog.count(),
+                        workLog.settlementAmount.sum()
                 ))
                 .from(workLog)
                 .join(workLog.workMatch, workMatch)

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
@@ -530,6 +530,7 @@ public class WorkMatchQueryRepository {
         QCaregiver caregiver = QCaregiver.caregiver;
         QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
 
+        LocalDate today = LocalDate.now();
         LocalDate startDate = LocalDate.now().minusDays(6); // 오늘 포함 최근 7일
 
         return queryFactory
@@ -543,10 +544,11 @@ public class WorkMatchQueryRepository {
                 .join(workLog.workMatch, workMatch)
                 .join(workMatch.caregiver, caregiver)
                 .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
-                .where(workLog.isPaid.eq(false)
+                .where(workLog.isPaid.eq(  false)
                         .and(workMatch.status.ne(WorkStatus.COMPLETED))
                         .and(caregiverCenter.center.centerId.eq(centerId))
-                        .and(workMatch.workDate.goe(startDate)))
+                        .and(workMatch.workDate.between(startDate, today))
+                )
                 .groupBy(workMatch.workDate)
                 .orderBy(workMatch.workDate.desc())
                 .fetch();

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
@@ -545,7 +545,7 @@ public class WorkMatchQueryRepository {
                 .join(workLog.workMatch, workMatch)
                 .join(workMatch.caregiver, caregiver)
                 .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
-                .where(workLog.isPaid.eq(  false)
+                .where(workLog.isPaid.eq(false)
                         .and(workMatch.status.ne(WorkStatus.COMPLETED))
                         .and(caregiverCenter.center.centerId.eq(centerId))
                         .and(workMatch.workDate.between(startDate, today))

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchQueryRepository.java
@@ -72,7 +72,7 @@ public class WorkMatchQueryRepository {
                         workMatch.workDate.between(startDate, endDate),
                         caregiverCenter.center.centerId.eq(centerId)
                 )
-                .orderBy(workMatch.workDate.desc())
+                .orderBy(workMatch.workDate.desc(), workMatch.createdAt.desc())
                 .fetch();
 
         // 2. caregiverId 추출
@@ -274,6 +274,7 @@ public class WorkMatchQueryRepository {
                 .leftJoin(workLog).on(workLog.workMatch.eq(workMatch))
                 .where(caregiverCenter.center.centerId.eq(centerId))
                 .groupBy(workMatch.status)
+                .orderBy(workMatch.createdAt.desc())
                 .fetch();
 
         BigDecimal totalAmount = BigDecimal.ZERO;
@@ -550,7 +551,7 @@ public class WorkMatchQueryRepository {
                         .and(workMatch.workDate.between(startDate, today))
                 )
                 .groupBy(workMatch.workDate)
-                .orderBy(workMatch.workDate.desc())
+                .orderBy(workMatch.workDate.year().desc(), workMatch.workDate.month().desc())
                 .fetch();
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/repository/WorkMatchRepository.java
@@ -4,12 +4,16 @@ import jaega.homecare.domain.WorkMatch.entity.WorkMatch;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 public interface WorkMatchRepository extends JpaRepository<WorkMatch, Long> {
     Optional<WorkMatch> findByWorkMatchId(UUID workMatchId);
 
     List<WorkMatch> findByCaregiverOrderByIdDesc(Caregiver caregiver);
+
+    List<WorkMatch> findByCaregiverAndWorkDateIn(Caregiver caregiver, Set<LocalDate> workDates);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/service/command/WorkMatchCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/service/command/WorkMatchCommandService.java
@@ -4,6 +4,7 @@ import jaega.homecare.domain.WorkLog.dto.req.CreateWorkLogRequest;
 import jaega.homecare.domain.WorkLog.service.command.WorkLogCommandService;
 import jaega.homecare.domain.WorkMatch.dto.req.CreateWorkMatchRequest;
 import jaega.homecare.domain.WorkMatch.entity.WorkMatch;
+import jaega.homecare.domain.WorkMatch.entity.WorkStatus;
 import jaega.homecare.domain.WorkMatch.mapper.WorkMatchMapper;
 import jaega.homecare.domain.WorkMatch.repository.WorkMatchRepository;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
@@ -26,6 +27,16 @@ public class WorkMatchCommandService {
     private final CaregiverQueryService caregiverQueryService;
     private final WorkLogCommandService workLogCommandService;
     private final WorkMatchMapper workMatchMapper;
+
+    /**
+     * 특정 WorkMatch의 근무 상태 변경
+     */
+    public void changeWorkMatchStatus(UUID workMatchId, WorkStatus newStatus) {
+        WorkMatch workMatch = workMatchRepository.findByWorkMatchId(workMatchId)
+                .orElseThrow(() -> new IllegalArgumentException("WorkMatch not found: " + workMatchId));
+
+        workMatch.changeWorkStatus(newStatus);
+    }
 
     public void createWorkMatch(CreateWorkMatchRequest request){
         Caregiver caregiver = caregiverQueryService.getCaregiver(request.caregiverId());

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/service/query/WorkMatchQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/service/query/WorkMatchQueryService.java
@@ -51,7 +51,7 @@ public class WorkMatchQueryService {
     // 정산 페이지
 
     // 정산 금액, 정산 건수 통계 조회
-    public GetSettlementSummaryResponse getSettlementSummary(UUID centerId){
+    public GetSettlementCenterSummaryResponse getSettlementSummary(UUID centerId){
         return workMatchQueryRepository.getSettlementSummary(centerId);
     }
 
@@ -77,6 +77,13 @@ public class WorkMatchQueryService {
      */
     public List<GetDailyUnsettledResponse> getDailyUnsettledCount(UUID centerId) {
         return workMatchQueryRepository.getDailyUnsettledCount(centerId);
+    }
+
+    /**
+     * 요양보호사의 정산 내역 요약 조회
+     */
+    public GetCaregiverSettlementSummaryResponse getCaregiverSettlementSummary(UUID caregiverId){
+        return workMatchQueryRepository.getCaregiverSettlementSummary(caregiverId);
     }
 }
 

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/service/query/WorkMatchQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/service/query/WorkMatchQueryService.java
@@ -35,9 +35,9 @@ public class WorkMatchQueryService {
     }
 
     public GetDashboardWorkStatusResponse getDashboardWorkStatus(UUID centerId) {
-        long workingToday = workMatchQueryRepository.countCaregiversWorkingToday(centerId);
-        long unassigned = workMatchQueryRepository.countUnassignedCaregiversToday(centerId);
-        long waiting = workMatchQueryRepository.countWaitingApplicants(centerId);
+        Long workingToday = workMatchQueryRepository.countCaregiversWorkingToday(centerId);
+        Long unassigned = workMatchQueryRepository.countUnassignedCaregiversToday(centerId);
+        Long waiting = workMatchQueryRepository.countWaitingApplicants(centerId);
         List<WorkPlaceDistribution> distribution = workMatchQueryRepository.getWorkPlaceDistributionByServiceType(centerId);
 
         return new GetDashboardWorkStatusResponse(
@@ -52,36 +52,40 @@ public class WorkMatchQueryService {
 
     // 정산 금액, 정산 건수 통계 조회
     public GetSettlementCenterSummaryResponse getSettlementSummary(UUID centerId){
-        return workMatchQueryRepository.getSettlementSummary(centerId);
+        return workMatchQueryRepository.getSettlementCenterSummary(centerId);
     }
 
-    // 요양보호사 정산 내역 목록 조회
+    // 센터의 요양보호사 정산 내역 목록 조회
     public List<GetCaregiverWorkResponse> getCaregiverWorkList(
             UUID centerId,
             WorkStatus status,
-            int year,
-            int month
+            Integer year,
+            Integer month
     ) {
-        return workMatchQueryRepository.getCaregiverWorkList(centerId, status, year, month);
+        return workMatchQueryRepository.getCaregiverWorkListByCenter(centerId, status, year, month);
     }
 
-    /**
-     * 최근 6개월 총 정산 금액
-     */
+    // 요양보호사 개별 정산 내역 목록 조회
+    public List<GetCaregiverWorkResponse> getCaregiverWorkListByCaregiver(
+            UUID caregiverId,
+            WorkStatus status,
+            Integer year,
+            Integer month
+    ) {
+        return workMatchQueryRepository.getCaregiverWorkListByCaregiver(caregiverId, status, year, month);
+    }
+
+    // 최근 6개월 간 정산 내역 조회
     public List<GetMonthlyPaymentResponse> getMonthlyPaidSettlements(UUID centerId) {
         return workMatchQueryRepository.getMonthlyPaidSettlements(centerId, 6); // 이번 달 포함 6개월
     }
 
-    /**
-     * 최근 7일 미정산 건수
-     */
+    // 최근 7일간 미정산 된 건수 조회
     public List<GetDailyUnsettledResponse> getDailyUnsettledCount(UUID centerId) {
         return workMatchQueryRepository.getDailyUnsettledCount(centerId);
     }
 
-    /**
-     * 요양보호사의 정산 내역 요약 조회
-     */
+    // 요양 보호사의 정산 내역 조회
     public GetCaregiverSettlementSummaryResponse getCaregiverSettlementSummary(UUID caregiverId){
         return workMatchQueryRepository.getCaregiverSettlementSummary(caregiverId);
     }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/service/query/WorkMatchQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/service/query/WorkMatchQueryService.java
@@ -2,15 +2,12 @@ package jaega.homecare.domain.WorkMatch.service.query;
 
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesByMonth;
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesResponse;
+import jaega.homecare.domain.WorkMatch.dto.res.GetDashboardWorkStatusResponse;
+import jaega.homecare.domain.WorkMatch.dto.res.WorkPlaceDistribution;
 import jaega.homecare.domain.WorkMatch.entity.WorkMatch;
-import jaega.homecare.domain.WorkMatch.mapper.WorkMatchMapper;
 import jaega.homecare.domain.WorkMatch.repository.WorkMatchQueryRepository;
 import jaega.homecare.domain.WorkMatch.repository.WorkMatchRepository;
-import jaega.homecare.domain.caregiver.entity.Caregiver;
-import jaega.homecare.domain.caregiver.repository.CaregiverRepository;
-import jaega.homecare.domain.caregiver.service.query.CaregiverQueryService;
 import jaega.homecare.domain.serviceMatch.repository.ServiceMatchQueryRepository;
-import jaega.homecare.domain.serviceMatch.service.query.ServiceMatchQueryService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,6 +34,20 @@ public class WorkMatchQueryService {
 
     public List<GetCaregiverMatchesByMonth> getWorkMatchesByMonth(UUID centerId, int year, int month, Integer day) {
         return workMatchQueryRepository.findWorkMatchesByMonth(centerId, year, month, day);
+    }
+
+    public GetDashboardWorkStatusResponse getDashboardWorkStatus(UUID centerId) {
+        long workingToday = workMatchQueryRepository.countCaregiversWorkingToday(centerId);
+        long unassigned = workMatchQueryRepository.countUnassignedCaregiversToday(centerId);
+        long waiting = workMatchQueryRepository.countWaitingApplicants(centerId);
+        List<WorkPlaceDistribution> distribution = workMatchQueryRepository.getWorkPlaceDistributionByServiceType(centerId);
+
+        return new GetDashboardWorkStatusResponse(
+                workingToday,
+                unassigned,
+                waiting,
+                distribution
+        );
     }
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/service/query/WorkMatchQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/service/query/WorkMatchQueryService.java
@@ -1,10 +1,8 @@
 package jaega.homecare.domain.WorkMatch.service.query;
 
-import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesByMonth;
-import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesResponse;
-import jaega.homecare.domain.WorkMatch.dto.res.GetDashboardWorkStatusResponse;
-import jaega.homecare.domain.WorkMatch.dto.res.WorkPlaceDistribution;
+import jaega.homecare.domain.WorkMatch.dto.res.*;
 import jaega.homecare.domain.WorkMatch.entity.WorkMatch;
+import jaega.homecare.domain.WorkMatch.entity.WorkStatus;
 import jaega.homecare.domain.WorkMatch.repository.WorkMatchQueryRepository;
 import jaega.homecare.domain.WorkMatch.repository.WorkMatchRepository;
 import jaega.homecare.domain.serviceMatch.repository.ServiceMatchQueryRepository;
@@ -50,4 +48,15 @@ public class WorkMatchQueryService {
         );
     }
 
+    // 정산 페이지
+    public List<GetCaregiverWorkResponse> getCaregiverWorkList(
+            UUID centerId,
+            WorkStatus status,
+            int year,
+            int month
+    ) {
+        return workMatchQueryRepository.getCaregiverWorkList(centerId, status, year, month);
+    }
 }
+
+

--- a/homecare/src/main/java/jaega/homecare/domain/WorkMatch/service/query/WorkMatchQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/WorkMatch/service/query/WorkMatchQueryService.java
@@ -49,6 +49,13 @@ public class WorkMatchQueryService {
     }
 
     // 정산 페이지
+
+    // 정산 금액, 정산 건수 통계 조회
+    public GetSettlementSummaryResponse getSettlementSummary(UUID centerId){
+        return workMatchQueryRepository.getSettlementSummary(centerId);
+    }
+
+    // 요양보호사 정산 내역 목록 조회
     public List<GetCaregiverWorkResponse> getCaregiverWorkList(
             UUID centerId,
             WorkStatus status,
@@ -56,6 +63,20 @@ public class WorkMatchQueryService {
             int month
     ) {
         return workMatchQueryRepository.getCaregiverWorkList(centerId, status, year, month);
+    }
+
+    /**
+     * 최근 6개월 총 정산 금액
+     */
+    public List<GetMonthlyPaymentResponse> getMonthlyPaidSettlements(UUID centerId) {
+        return workMatchQueryRepository.getMonthlyPaidSettlements(centerId, 6); // 이번 달 포함 6개월
+    }
+
+    /**
+     * 최근 7일 미정산 건수
+     */
+    public List<GetDailyUnsettledResponse> getDailyUnsettledCount(UUID centerId) {
+        return workMatchQueryRepository.getDailyUnsettledCount(centerId);
     }
 }
 

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/dto/res/GetDashboardPopularResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/dto/res/GetDashboardPopularResponse.java
@@ -1,0 +1,10 @@
+package jaega.homecare.domain.caregiver.dto.res;
+
+public record GetDashboardPopularResponse(
+        Long total,
+        Long active,
+        Long inactive,
+        Long resigned,
+        Long newsThisMonth
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
@@ -5,6 +5,7 @@ import jaega.homecare.domain.center.entity.Center;
 import jaega.homecare.domain.users.entity.Location;
 import jaega.homecare.domain.users.entity.ServiceType;
 import jaega.homecare.domain.users.entity.User;
+import jaega.homecare.global.audit.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,7 +21,7 @@ import java.util.UUID;
 @Getter
 @Table(name = "caregiver")
 @NoArgsConstructor
-public class Caregiver {
+public class Caregiver extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverQueryRepository.java
@@ -1,12 +1,12 @@
 package jaega.homecare.domain.caregiver.repository;
 
 import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.caregiverCenter.entity.CaregiverCenter;
 import jaega.homecare.domain.caregiverCenter.entity.CaregiverStatus;
 import jaega.homecare.domain.caregiver.entity.QCaregiver;
+import jaega.homecare.domain.center.entity.Center;
 import jaega.homecare.domain.caregiverCenter.entity.QCaregiverCenter;
 import jaega.homecare.domain.users.entity.ServiceType;
 import jaega.homecare.domain.center.dto.res.GetCaregiverByCaregiverStatusResponse;
@@ -108,12 +108,14 @@ public class CaregiverQueryRepository {
 
     public Long countNewCaregiversThisMonth(Center center) {
         QCaregiver caregiver = QCaregiver.caregiver;
+        QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
 
         return queryFactory
-                .select(caregiver.count())
-                .from(caregiver)
+                .select(caregiver.countDistinct())
+                .from(caregiverCenter)
+                .join(caregiverCenter.caregiver, caregiver)
                 .where(
-                        caregiver.center.centerId.eq(center.getCenterId())
+                        caregiverCenter.center.centerId.eq(center.getCenterId())
                                 .and(Expressions.booleanTemplate(
                                         "function('date_trunc', 'month', {0}) = function('date_trunc', 'month', current_date)",
                                         caregiver.createdAt
@@ -121,5 +123,4 @@ public class CaregiverQueryRepository {
                 )
                 .fetchOne();
     }
-
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverQueryRepository.java
@@ -123,4 +123,27 @@ public class CaregiverQueryRepository {
                 )
                 .fetchOne();
     }
+
+    public Long countByCenterId(UUID centerId) {
+        QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
+
+        return queryFactory
+                .select(caregiverCenter.count())
+                .from(caregiverCenter)
+                .where(caregiverCenter.center.centerId.eq(centerId))
+                .fetchOne();
+    }
+
+    public Long countByCenterAndStatus(UUID centerId, CaregiverStatus status) {
+        QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
+
+        return queryFactory
+                .select(caregiverCenter.count())
+                .from(caregiverCenter)
+                .where(
+                        caregiverCenter.center.centerId.eq(centerId)
+                                .and(caregiverCenter.status.eq(status))
+                )
+                .fetchOne();
+    }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverQueryRepository.java
@@ -1,9 +1,11 @@
 package jaega.homecare.domain.caregiver.repository;
 
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.caregiver.entity.CaregiverStatus;
 import jaega.homecare.domain.caregiver.entity.QCaregiver;
+import jaega.homecare.domain.center.entity.Center;
 import jaega.homecare.domain.users.entity.ServiceType;
 import jaega.homecare.domain.center.dto.res.GetCaregiverByCaregiverStatusResponse;
 import jaega.homecare.domain.center.dto.res.GetCaregiverByServiceTypeResponse;
@@ -84,4 +86,21 @@ public class CaregiverQueryRepository {
                 ))
                 .toList();
     }
+
+    public Long countNewCaregiversThisMonth(Center center) {
+        QCaregiver caregiver = QCaregiver.caregiver;
+
+        return queryFactory
+                .select(caregiver.count())
+                .from(caregiver)
+                .where(
+                        caregiver.center.centerId.eq(center.getCenterId())
+                                .and(Expressions.booleanTemplate(
+                                        "function('date_trunc', 'month', {0}) = function('date_trunc', 'month', current_date)",
+                                        caregiver.createdAt
+                                ))
+                )
+                .fetchOne();
+    }
+
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverRepository.java
@@ -20,10 +20,4 @@ public interface CaregiverRepository extends JpaRepository<Caregiver, Long>{
 
     @Query("select c.caregiverId, st from Caregiver c join c.serviceTypes st where c.caregiverId in :caregiverIds")
     List<Object[]> findServiceTypesByCaregiverIds(@Param("caregiverIds") Set<UUID> caregiverIds);
-
-    @Query("SELECT COUNT(cc) FROM CaregiverCenter cc WHERE cc.center.centerId = :centerId")
-    Long countByCenterId(@Param("centerId") UUID centerId);
-
-    @Query("SELECT COUNT(cc) FROM CaregiverCenter cc WHERE cc.center.centerId = :centerId AND cc.status = :status")
-    Long countByCenterAndStatus(@Param("centerId") UUID centerId, @Param("status") CaregiverStatus status);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverRepository.java
@@ -2,6 +2,7 @@ package jaega.homecare.domain.caregiver.repository;
 
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.caregiver.entity.CaregiverStatus;
+import jaega.homecare.domain.center.entity.Center;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -22,4 +23,9 @@ public interface CaregiverRepository extends JpaRepository<Caregiver, Long>{
 
     @Query("select c.id, st from Caregiver c join c.serviceTypes st where c.caregiverId in :caregiverIds")
     List<Object[]> findServiceTypesByCaregiverIds(@Param("caregiverIds") Set<UUID> caregiverIds);
+
+
+    Long countByCenter(Center center);
+
+    Long countByCenterAndStatus(Center center, CaregiverStatus status);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverRepository.java
@@ -21,8 +21,9 @@ public interface CaregiverRepository extends JpaRepository<Caregiver, Long>{
     @Query("select c.caregiverId, st from Caregiver c join c.serviceTypes st where c.caregiverId in :caregiverIds")
     List<Object[]> findServiceTypesByCaregiverIds(@Param("caregiverIds") Set<UUID> caregiverIds);
 
+    @Query("SELECT COUNT(cc) FROM CaregiverCenter cc WHERE cc.center.centerId = :centerId")
+    Long countByCenterId(@Param("centerId") UUID centerId);
 
-    Long countByCenter(Center center);
-
-    Long countByCenterAndStatus(Center center, CaregiverStatus status);
+    @Query("SELECT COUNT(cc) FROM CaregiverCenter cc WHERE cc.center.centerId = :centerId AND cc.status = :status")
+    Long countByCenterAndStatus(@Param("centerId") UUID centerId, @Param("status") CaregiverStatus status);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/service/query/CaregiverQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/service/query/CaregiverQueryService.java
@@ -1,5 +1,6 @@
 package jaega.homecare.domain.caregiver.service.query;
 
+import jaega.homecare.domain.caregiver.dto.res.GetDashboardPopularResponse;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.caregiver.entity.CaregiverStatus;
 import jaega.homecare.domain.caregiver.mapper.CaregiverMapper;
@@ -9,6 +10,8 @@ import jaega.homecare.domain.center.dto.res.GetCaregiverByCaregiverStatusRespons
 import jaega.homecare.domain.center.dto.res.GetCaregiverByServiceTypeResponse;
 import jaega.homecare.domain.center.dto.res.GetCaregiverProfileResponse;
 import jaega.homecare.domain.center.dto.res.GetCaregiverResponse;
+import jaega.homecare.domain.center.entity.Center;
+import jaega.homecare.domain.center.service.query.CenterQueryService;
 import jaega.homecare.domain.users.entity.ServiceType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,6 +25,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class CaregiverQueryService {
 
+    private final CenterQueryService centerQueryService;
     private final CaregiverQueryRepository caregiverQueryRepository;
     private final CaregiverRepository caregiverRepository;
     private final CaregiverMapper caregiverMapper;
@@ -47,4 +51,18 @@ public class CaregiverQueryService {
         Caregiver caregiver = getCaregiver(caregiverId);
         return caregiverMapper.toGetCaregiverProfile(caregiver);
     }
+
+
+    public GetDashboardPopularResponse getCaregiverStats(UUID centerId) {
+        Center center = centerQueryService.getCenterByUUID(centerId);
+
+        Long total = caregiverRepository.countByCenter(center);
+        Long active = caregiverRepository.countByCenterAndStatus(center, CaregiverStatus.ACTIVE);
+        Long inactive = caregiverRepository.countByCenterAndStatus(center, CaregiverStatus.INACTIVE);
+        Long resigned = caregiverRepository.countByCenterAndStatus(center, CaregiverStatus.RESIGNED);
+        Long newThisMonth = caregiverQueryRepository.countNewCaregiversThisMonth(center);
+
+        return new GetDashboardPopularResponse(total, active, inactive, resigned, newThisMonth);
+    }
+
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/service/query/CaregiverQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/service/query/CaregiverQueryService.java
@@ -56,10 +56,10 @@ public class CaregiverQueryService {
     public GetDashboardPopularResponse getCaregiverStats(UUID centerId) {
         Center center = centerQueryService.getCenterByUUID(centerId);
 
-        Long total = caregiverRepository.countByCenterId(center.getCenterId());
-        Long active = caregiverRepository.countByCenterAndStatus(center.getCenterId(), CaregiverStatus.ACTIVE);
-        Long inactive = caregiverRepository.countByCenterAndStatus(center.getCenterId(), CaregiverStatus.INACTIVE);
-        Long resigned = caregiverRepository.countByCenterAndStatus(center.getCenterId(), CaregiverStatus.RESIGNED);
+        Long total = caregiverQueryRepository.countByCenterId(center.getCenterId());
+        Long active = caregiverQueryRepository.countByCenterAndStatus(center.getCenterId(), CaregiverStatus.ACTIVE);
+        Long inactive = caregiverQueryRepository.countByCenterAndStatus(center.getCenterId(), CaregiverStatus.INACTIVE);
+        Long resigned = caregiverQueryRepository.countByCenterAndStatus(center.getCenterId(), CaregiverStatus.RESIGNED);
         Long newThisMonth = caregiverQueryRepository.countNewCaregiversThisMonth(center);
 
         return new GetDashboardPopularResponse(total, active, inactive, resigned, newThisMonth);

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/service/query/CaregiverQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/service/query/CaregiverQueryService.java
@@ -56,10 +56,10 @@ public class CaregiverQueryService {
     public GetDashboardPopularResponse getCaregiverStats(UUID centerId) {
         Center center = centerQueryService.getCenterByUUID(centerId);
 
-        Long total = caregiverRepository.countByCenter(center);
-        Long active = caregiverRepository.countByCenterAndStatus(center, CaregiverStatus.ACTIVE);
-        Long inactive = caregiverRepository.countByCenterAndStatus(center, CaregiverStatus.INACTIVE);
-        Long resigned = caregiverRepository.countByCenterAndStatus(center, CaregiverStatus.RESIGNED);
+        Long total = caregiverRepository.countByCenterId(center.getCenterId());
+        Long active = caregiverRepository.countByCenterAndStatus(center.getCenterId(), CaregiverStatus.ACTIVE);
+        Long inactive = caregiverRepository.countByCenterAndStatus(center.getCenterId(), CaregiverStatus.INACTIVE);
+        Long resigned = caregiverRepository.countByCenterAndStatus(center.getCenterId(), CaregiverStatus.RESIGNED);
         Long newThisMonth = caregiverQueryRepository.countNewCaregiversThisMonth(center);
 
         return new GetDashboardPopularResponse(total, active, inactive, resigned, newThisMonth);

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverCenter/repository/CaregiverCenterRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverCenter/repository/CaregiverCenterRepository.java
@@ -1,7 +1,12 @@
 package jaega.homecare.domain.caregiverCenter.repository;
 
 import jaega.homecare.domain.caregiverCenter.entity.CaregiverCenter;
+import jaega.homecare.domain.caregiverCenter.entity.CaregiverStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CaregiverCenterRepository extends JpaRepository<CaregiverCenter, Long> {
+
+    List<CaregiverCenter> findByStatus(CaregiverStatus status);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jaega.homecare.domain.WorkLog.dto.res.GetDashboardSettlementResponse;
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesByMonth;
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesResponse;
+import jaega.homecare.domain.WorkMatch.dto.res.GetDashboardWorkStatusResponse;
 import jaega.homecare.domain.caregiver.dto.req.CreateCertificationRequest;
 import jaega.homecare.domain.caregiver.dto.res.GetCertificationResponse;
 import jaega.homecare.domain.caregiver.dto.res.GetDashboardPopularResponse;
@@ -112,4 +113,9 @@ public interface CenterController {
     @ApiResponse(responseCode = "200", description = "센터 대시보드에 정산 현황 조회 성공")
     @GetMapping("/dashboard/settlement")
     ResponseEntity<GetDashboardSettlementResponse> getDashboardSettlement(@RequestParam UUID centerId);
+
+    @Operation(summary = "센터 대시보드의 근무 현황 조회", description = "센터 대시보드에서 근무 현황을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "센터 대시보드에 근무 현황 조회 성공")
+    @GetMapping("/dashboard/workStatus")
+    ResponseEntity<GetDashboardWorkStatusResponse> getDashboardWorkStatus(@RequestParam UUID centerId);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
@@ -7,6 +7,7 @@ import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesByMonth;
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesResponse;
 import jaega.homecare.domain.caregiver.dto.req.CreateCertificationRequest;
 import jaega.homecare.domain.caregiver.dto.res.GetCertificationResponse;
+import jaega.homecare.domain.caregiver.dto.res.GetDashboardPopularResponse;
 import jaega.homecare.domain.caregiver.entity.CaregiverStatus;
 import jaega.homecare.domain.center.dto.req.*;
 import jaega.homecare.domain.center.dto.res.*;
@@ -100,4 +101,9 @@ public interface CenterController {
     @ApiResponse(responseCode = "200", description = "요양보호사 인사카드 조회 성공")
     @GetMapping("/profile")
     ResponseEntity<GetCaregiverProfileResponse>getCaregiverProfile(@RequestParam UUID caregiverId);
+
+    @Operation(summary = "센터 대시보드의 요양보호사 인구 현황 조회", description = "센터 대시보드에서 요양보호사 인구 현황을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "센터 대시보드에 요양보호사 인구 현황 조회 성공")
+    @GetMapping("/dashboard/popular")
+    ResponseEntity<GetDashboardPopularResponse> getDashboardPopular(@RequestParam UUID centerId);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
@@ -3,6 +3,7 @@ package jaega.homecare.domain.center.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jaega.homecare.domain.WorkLog.dto.res.GetDashboardSettlementResponse;
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesByMonth;
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesResponse;
 import jaega.homecare.domain.caregiver.dto.req.CreateCertificationRequest;
@@ -106,4 +107,9 @@ public interface CenterController {
     @ApiResponse(responseCode = "200", description = "센터 대시보드에 요양보호사 인구 현황 조회 성공")
     @GetMapping("/dashboard/popular")
     ResponseEntity<GetDashboardPopularResponse> getDashboardPopular(@RequestParam UUID centerId);
+
+    @Operation(summary = "센터 대시보드의 정산 현황 조회", description = "센터 대시보드에서 정산 현황을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "센터 대시보드에 정산 현황 조회 성공")
+    @GetMapping("/dashboard/settlement")
+    ResponseEntity<GetDashboardSettlementResponse> getDashboardSettlement(@RequestParam UUID centerId);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
@@ -1,5 +1,7 @@
 package jaega.homecare.domain.center.controller;
 
+import jaega.homecare.domain.WorkLog.dto.res.GetDashboardSettlementResponse;
+import jaega.homecare.domain.WorkLog.service.query.WorkLogQueryService;
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesByMonth;
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesResponse;
 import jaega.homecare.domain.WorkMatch.service.query.WorkMatchQueryService;
@@ -41,6 +43,7 @@ public class CenterControllerImpl implements CenterController{
     private final CaregiverQueryService caregiverQueryService;
     private final ServiceMatchQueryService serviceMatchQueryService;
     private final WorkMatchQueryService workMatchQueryService;
+    private final WorkLogQueryService workLogQueryService;
     private final CertificationCommandService certificationCommandService;
     private final CertificationQueryService certificationQueryService;
 
@@ -143,6 +146,12 @@ public class CenterControllerImpl implements CenterController{
     @Override
     public ResponseEntity<GetDashboardPopularResponse> getDashboardPopular(@RequestParam UUID centerId){
         GetDashboardPopularResponse response = caregiverQueryService.getCaregiverStats(centerId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<GetDashboardSettlementResponse> getDashboardSettlement(@RequestParam UUID centerId) {
+        GetDashboardSettlementResponse response = workLogQueryService.getSettlementStatus(centerId);
         return ResponseEntity.ok(response);
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
@@ -5,6 +5,7 @@ import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesResponse;
 import jaega.homecare.domain.WorkMatch.service.query.WorkMatchQueryService;
 import jaega.homecare.domain.caregiver.dto.req.CreateCertificationRequest;
 import jaega.homecare.domain.caregiver.dto.res.GetCertificationResponse;
+import jaega.homecare.domain.caregiver.dto.res.GetDashboardPopularResponse;
 import jaega.homecare.domain.caregiver.entity.CaregiverStatus;
 import jaega.homecare.domain.caregiver.service.command.CaregiverCommandService;
 import jaega.homecare.domain.caregiver.service.command.CertificationCommandService;
@@ -134,6 +135,14 @@ public class CenterControllerImpl implements CenterController{
     @Override
     public ResponseEntity<GetCaregiverProfileResponse >getCaregiverProfile(@RequestParam UUID caregiverId){
         GetCaregiverProfileResponse response = caregiverQueryService.getCaregiverProfile(caregiverId);
+        return ResponseEntity.ok(response);
+    }
+
+    // 대시보드 조회 Api
+
+    @Override
+    public ResponseEntity<GetDashboardPopularResponse> getDashboardPopular(@RequestParam UUID centerId){
+        GetDashboardPopularResponse response = caregiverQueryService.getCaregiverStats(centerId);
         return ResponseEntity.ok(response);
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
@@ -4,6 +4,7 @@ import jaega.homecare.domain.WorkLog.dto.res.GetDashboardSettlementResponse;
 import jaega.homecare.domain.WorkLog.service.query.WorkLogQueryService;
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesByMonth;
 import jaega.homecare.domain.WorkMatch.dto.res.GetCaregiverMatchesResponse;
+import jaega.homecare.domain.WorkMatch.dto.res.GetDashboardWorkStatusResponse;
 import jaega.homecare.domain.WorkMatch.service.query.WorkMatchQueryService;
 import jaega.homecare.domain.caregiver.dto.req.CreateCertificationRequest;
 import jaega.homecare.domain.caregiver.dto.res.GetCertificationResponse;
@@ -152,6 +153,12 @@ public class CenterControllerImpl implements CenterController{
     @Override
     public ResponseEntity<GetDashboardSettlementResponse> getDashboardSettlement(@RequestParam UUID centerId) {
         GetDashboardSettlementResponse response = workLogQueryService.getSettlementStatus(centerId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<GetDashboardWorkStatusResponse> getDashboardWorkStatus(@RequestParam UUID centerId){
+        GetDashboardWorkStatusResponse response = workMatchQueryService.getDashboardWorkStatus(centerId);
         return ResponseEntity.ok(response);
     }
 }

--- a/homecare/src/main/java/jaega/homecare/global/audit/BaseTimeEntity.java
+++ b/homecare/src/main/java/jaega/homecare/global/audit/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package jaega.homecare.global.audit;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "modified_at")
+    private LocalDateTime modifiedAt;
+}

--- a/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
+++ b/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
@@ -13,6 +13,7 @@ import jaega.homecare.domain.caregiver.entity.Certification;
 import jaega.homecare.domain.caregiver.repository.CaregiverRepository;
 import jaega.homecare.domain.caregiver.repository.CertificationRepository;
 import jaega.homecare.domain.caregiverCenter.entity.CaregiverCenter;
+import jaega.homecare.domain.caregiverCenter.entity.CaregiverStatus;
 import jaega.homecare.domain.caregiverCenter.repository.CaregiverCenterRepository;
 import jaega.homecare.domain.center.entity.Center;
 import jaega.homecare.domain.center.repository.CenterRepository;
@@ -149,10 +150,22 @@ public class DummyDataService {
                 .build();
         caregiverRepository.save(caregiver);
 
+        // 상태 랜덤 생성
+        CaregiverStatus status;
+        int statusRandom = random.nextInt(3);
+        if (statusRandom == 0) {
+            status = CaregiverStatus.ACTIVE;
+        } else if (statusRandom == 1) {
+            status = CaregiverStatus.INACTIVE;
+        } else {
+            status = CaregiverStatus.RESIGNED;
+        }
+
         CaregiverCenter caregiverCenter = CaregiverCenter.builder()
                 .caregiverCenterId(UUID.randomUUID())
                 .caregiver(caregiver)
                 .center(center)
+                .status(status)
                 .build();
         caregiverCenterRepository.save(caregiverCenter);
 
@@ -211,9 +224,14 @@ public class DummyDataService {
         serviceRequest.setServiceRequest(serviceRequestId, user, ServiceRequestStatus.PENDING, requestedDays);
         serviceRequestRepository.save(serviceRequest);
 
-        List<Caregiver> caregivers = caregiverRepository.findAll();
-        if (!caregivers.isEmpty()) {
-            Caregiver matchedCaregiver = caregivers.get(random.nextInt(caregivers.size()));
+        // CaregiverCenter가 ACTIVE인 요양보호사만 DB에서 조회
+        List<Caregiver> activeCaregivers = caregiverCenterRepository.findByStatus(CaregiverStatus.ACTIVE)
+                .stream()
+                .map(CaregiverCenter::getCaregiver)
+                .toList();
+
+        if (!activeCaregivers.isEmpty()) {
+            Caregiver matchedCaregiver = activeCaregivers.get(random.nextInt(activeCaregivers.size()));
             UUID caregiverId = matchedCaregiver.getCaregiverId();
 
             // 거리 대충 87~125 사이 랜덤값
@@ -240,20 +258,17 @@ public class DummyDataService {
             );
             workMatchCommandService.createWorkMatch(createWorkMatchRequest);
 
-            // WorkMatch 일부를 COMPLETED 상태로 변경
+            // WorkMatch 상태 설정 (오늘 이후는 ACTIVE만 PLANNED)
             List<WorkMatch> createdMatches = workMatchRepository.findByCaregiverAndWorkDateIn(
                     matchedCaregiver, requestedDays
             );
 
-            // WorkMatch 상태 랜덤 설정
             for (WorkMatch match : createdMatches) {
                 LocalDate workDate = match.getWorkDate();
                 if (workDate.isBefore(now)) {
-                    // 과거 날짜
-                    int statusChoice = random.nextBoolean() ? 1 : 2; // 1: COMPLETED, 2: CANCELLED
+                    int statusChoice = random.nextBoolean() ? 1 : 2;
                     if (statusChoice == 1) {
                         workMatchCommandService.changeWorkMatchStatus(match.getWorkMatchId(), WorkStatus.COMPLETED);
-                        // COMPLETED이면 WorkLog 정산 완료
                         List<WorkLog> logs = workLogRepository.findByWorkMatch(match);
                         for (WorkLog log : logs) {
                             log.togglePaidStatus();
@@ -262,7 +277,6 @@ public class DummyDataService {
                         workMatchCommandService.changeWorkMatchStatus(match.getWorkMatchId(), WorkStatus.CANCELLED);
                     }
                 } else {
-                    // 오늘 이후 날짜
                     workMatchCommandService.changeWorkMatchStatus(match.getWorkMatchId(), WorkStatus.PLANNED);
                 }
             }

--- a/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
+++ b/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
@@ -1,6 +1,12 @@
 package jaega.homecare.global.dummy.service;
 
+import jaega.homecare.domain.WorkLog.entity.WorkLog;
+import jaega.homecare.domain.WorkLog.repository.WorkLogRepository;
+import jaega.homecare.domain.WorkLog.service.command.WorkLogCommandService;
 import jaega.homecare.domain.WorkMatch.dto.req.CreateWorkMatchRequest;
+import jaega.homecare.domain.WorkMatch.entity.WorkMatch;
+import jaega.homecare.domain.WorkMatch.entity.WorkStatus;
+import jaega.homecare.domain.WorkMatch.repository.WorkMatchRepository;
 import jaega.homecare.domain.WorkMatch.service.command.WorkMatchCommandService;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.caregiver.entity.Certification;
@@ -41,12 +47,15 @@ public class DummyDataService {
 
     private final ServiceMatchCommandService serviceMatchCommandService;
     private final WorkMatchCommandService workMatchCommandService;
+    private final WorkMatchRepository workMatchRepository;
+    private final WorkLogRepository workLogRepository;
+    private final WorkLogCommandService workLogCommandService;
     private final Random random = new Random();
 
     @Transactional
     public void generateAllDummyData() {
         // 1. 모든 사용자 데이터 먼저 생성
-        IntStream.range(0, 60).forEach(this::createDummyUser);
+        IntStream.range(0, 100).forEach(this::createDummyUser);
 
         // 2. Center와 Caregiver는 USER 데이터에 의존하므로, USER 생성 후 실행
 
@@ -174,9 +183,18 @@ public class DummyDataService {
         }
 
         Set<LocalDate> requestedDays = new HashSet<>();
-        int daysToRequest = 1;
-        for (int i = 0; i < daysToRequest; i++) {
-            requestedDays.add(LocalDate.now().plusDays(random.nextInt(2) + 1));
+        int pastDaysCount = random.nextInt(3) + 1; // 1~3일 과거
+        int futureDaysCount = 1; // 기존 1일 이후
+        LocalDate now = LocalDate.now();
+
+        // 과거 날짜 추가 (오늘 기준 6개월 내)
+        for (int i = 0; i < pastDaysCount; i++) {
+            requestedDays.add(now.minusDays(random.nextInt(30 * 6))); // 6개월 내 과거
+        }
+
+        // 미래 날짜 추가
+        for (int i = 0; i < futureDaysCount; i++) {
+            requestedDays.add(now.plusDays(random.nextInt(2) + 1));
         }
 
         ServiceRequest serviceRequest = ServiceRequest.builder()
@@ -221,6 +239,33 @@ public class DummyDataService {
                     distanceLog
             );
             workMatchCommandService.createWorkMatch(createWorkMatchRequest);
+
+            // WorkMatch 일부를 COMPLETED 상태로 변경
+            List<WorkMatch> createdMatches = workMatchRepository.findByCaregiverAndWorkDateIn(
+                    matchedCaregiver, requestedDays
+            );
+
+            // WorkMatch 상태 랜덤 설정
+            for (WorkMatch match : createdMatches) {
+                LocalDate workDate = match.getWorkDate();
+                if (workDate.isBefore(now)) {
+                    // 과거 날짜
+                    int statusChoice = random.nextBoolean() ? 1 : 2; // 1: COMPLETED, 2: CANCELLED
+                    if (statusChoice == 1) {
+                        workMatchCommandService.changeWorkMatchStatus(match.getWorkMatchId(), WorkStatus.COMPLETED);
+                        // COMPLETED이면 WorkLog 정산 완료
+                        List<WorkLog> logs = workLogRepository.findByWorkMatch(match);
+                        for (WorkLog log : logs) {
+                            log.togglePaidStatus();
+                        }
+                    } else {
+                        workMatchCommandService.changeWorkMatchStatus(match.getWorkMatchId(), WorkStatus.CANCELLED);
+                    }
+                } else {
+                    // 오늘 이후 날짜
+                    workMatchCommandService.changeWorkMatchStatus(match.getWorkMatchId(), WorkStatus.PLANNED);
+                }
+            }
         }
     }
 }

--- a/homecare/src/test/java/jaega/homecare/HomecareApplicationTests.java
+++ b/homecare/src/test/java/jaega/homecare/HomecareApplicationTests.java
@@ -1,4 +1,4 @@
-package com.jaega.homecare;
+package jaega.homecare;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #25 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 1. 관리자 웹 페이지의 대시보드 api를 추가했습니다. 
- 프론트에 맞게 관리자 웹 페이지의 대시보드에 필요한 api를 추가했습니다.

### 2. 정산 관련 api를 추가했습니다.
- 프론트에 맞게 정산 관련 api를 추가했습니다.
- 정산 금액은 근무 기록이 작성될 시 시간(임의로 15000원으로 지정) * 거리로 계산했습니다.
- 정산 api에서 근무 일자가 필요하면 WorkMatch를, 상세 시간과 이동거리가 필요하면 WorkLog로 분류하여 작업했습니다.
(WorkMatch에는 근무 시간, 일자가 있고 WorkLog는 근무 시간, 이동 거리만 존재)
- 정산된 건 수 조회 시엔 다음과 같은 조건을 따릅니다.
> 1. WorkMatch의 근무 상태가 'COMPLETED'인 상태,  
> 2. WorkLog의 근무 기록의 is_paid(정산 여부)가 활성화 된 상태



### 스크린샷 (선택)

<br>

## 💬리뷰 요구사항(선택)

> WorkMatch에는 관리자 웹 페이지에서 근무 일자 관련 데이터를 조회하고, WorkLog는 근무 기록 관련 데이터를 조회합니다.
사실상 정산 내역을 조회할 땐 WorkMatch 도메인을 조회하고, 상세한 근무 기록이 필요할 땐 WorkLog를 조회합니다.
그런데, workLog의 특정 컨트롤러(workLog/workDay, workLog/paid)는 WorkMatch 도메인으로 옮겨도 될 법 합니다,,
이 도메인 구조를 어떻게 해야할 지 고민입니다,, !! 
