### PR TITLE
[#30] 수요자의 정기 제안 조회, 등록 api 구현 

### DIFF
--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
@@ -53,17 +53,15 @@ public class Caregiver extends BaseTimeEntity {
     @Column(name = "service_type")
     private Set<ServiceType> serviceTypes = new HashSet<>();
 
-    // 휴무일 (다중 선택 가능)
+    // 근무 가능 요일
     @ElementCollection(targetClass = DayOfWeek.class, fetch = FetchType.LAZY)
-    @CollectionTable(name = "days_off", joinColumns = @JoinColumn(name = "caregiver_id"))
+    @CollectionTable(name = "caregiver_day_of_week", joinColumns = @JoinColumn(name = "caregiver_id"))
     @Enumerated(EnumType.STRING)
     @Column(name = "day_of_week")
-    private Set<DayOfWeek> daysOff = new HashSet<>();
-
-    private String personalityType;
+    private Set<DayOfWeek> dayOfWeek = new HashSet<>();
 
     @Builder
-    public Caregiver(UUID caregiverId, User user, LocalTime availableStartTime, LocalTime availableEndTime, String address, Location location, Set<ServiceType> serviceTypes, Set<DayOfWeek> daysOff) {
+    public Caregiver(UUID caregiverId, User user, LocalTime availableStartTime, LocalTime availableEndTime, String address, Location location, Set<ServiceType> serviceTypes, Set<DayOfWeek> dayOfWeek) {
         this.caregiverId = caregiverId;
         this.user = user;
         this.availableStartTime = availableStartTime;
@@ -71,7 +69,7 @@ public class Caregiver extends BaseTimeEntity {
         this.address = address;
         this.location = location;
         this.serviceTypes = serviceTypes;
-        this.daysOff = daysOff;
+        this.dayOfWeek = dayOfWeek;
     }
 
     public void initializeCaregiver(UUID uuid) {
@@ -84,6 +82,6 @@ public class Caregiver extends BaseTimeEntity {
         this.address = request.address();
         this.location = request.location();
         this.serviceTypes = request.serviceTypes();
-        this.daysOff = request.daysOff();
+        this.dayOfWeek = request.dayOfWeek();
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/mapper/CaregiverMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/mapper/CaregiverMapper.java
@@ -26,7 +26,7 @@ public interface CaregiverMapper {
     @Mapping(target = "availableStartTime", ignore = true)
     @Mapping(target = "availableEndTime", ignore = true)
     @Mapping(target = "serviceTypes", ignore = true)
-    @Mapping(target = "daysOff", ignore = true)
+    @Mapping(target = "dayOfWeek", ignore = true)
     @Mapping(target = "location", ignore = true)
     Caregiver toEntity(String address, User user);
 

--- a/homecare/src/main/java/jaega/homecare/domain/center/dto/req/CreateCaregiverProfileRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/dto/req/CreateCaregiverProfileRequest.java
@@ -20,6 +20,6 @@ public record CreateCaregiverProfileRequest(
         String address,
         Location location,
         Set<ServiceType> serviceTypes,
-        Set<DayOfWeek> daysOff
+        Set<DayOfWeek> dayOfWeek
 ) {
 }

--- a/homecare/src/main/java/jaega/homecare/domain/match/processor/CaregiverFilterProcessor.java
+++ b/homecare/src/main/java/jaega/homecare/domain/match/processor/CaregiverFilterProcessor.java
@@ -29,7 +29,7 @@ public class CaregiverFilterProcessor {
     }
 
     private boolean isDayOff(Caregiver caregiver, DayOfWeek day) {
-        return caregiver.getDaysOff() != null && caregiver.getDaysOff().contains(day);
+        return caregiver.getDayOfWeek() != null && caregiver.getDayOfWeek().contains(day);
     }
 
     private boolean isAvailableAtTime(Caregiver caregiver, LocalTime start, LocalTime end) {

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/controller/RecurringOfferController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/controller/RecurringOfferController.java
@@ -1,0 +1,28 @@
+package jaega.homecare.domain.recurringOffer.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jaega.homecare.domain.recurringOffer.dto.req.CreateRecurringOfferRequest;
+import jaega.homecare.domain.recurringOffer.dto.res.GetRecurringOfferResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Tag(name = "RecurringOffer", description = "RecurringOffer(정기 제안) 서비스 API")
+@RequestMapping("/api/recurringOffer")
+public interface RecurringOfferController {
+
+    @Operation(summary = "정기 제안 신청 작성 API", description = "입력받은 정보로 수요자와 요양보호사 간의 정기 제안 신청을 생성합니다.")
+    @ApiResponse(responseCode = "204", description = "정기 제안 신청 작성 성공")
+    @PostMapping
+    ResponseEntity<Void> createRecurringOffer(@RequestBody CreateRecurringOfferRequest request);
+
+
+    @Operation(summary = "수요자의 정기 제안 신청 조회 API", description = "수요자가 작성한 정기 제안 신청서을 조회합니다.")
+    @ApiResponse(responseCode = "204", description = "수요자의 정기 제안 신청 조회 성공")
+    @GetMapping("/consumer/{consumerId}")
+    ResponseEntity<List<GetRecurringOfferResponse>> getRecurringOfferByConsumer(@PathVariable UUID consumerId);
+}

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/controller/RecurringOfferController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/controller/RecurringOfferController.java
@@ -2,11 +2,12 @@ package jaega.homecare.domain.recurringOffer.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jaega.homecare.domain.recurringOffer.dto.req.CreateRecurringOfferRequest;
+import jaega.homecare.domain.recurringOffer.dto.res.GetRecurringOfferDetailResponse;
 import jaega.homecare.domain.recurringOffer.dto.res.GetRecurringOfferResponse;
-import jaega.homecare.domain.recurringOffer.dto.res.RecommendRecurringOfferResponse;
+import jaega.homecare.domain.recurringOffer.dto.res.GetRecommendRecurringOfferResponse;
+import jaega.homecare.domain.recurringOffer.dto.res.GetUnreadRecurringOfferResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,6 +23,10 @@ public interface RecurringOfferController {
     @PostMapping
     ResponseEntity<Void> createRecurringOffer(@RequestBody CreateRecurringOfferRequest request);
 
+    @Operation(summary = "정기 제안 상세 조회 API", description = "작성된 정기 제안 신청서를 상세 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "정기 제안 신청 상세 조회 성공")
+    @GetMapping("/{recurringOfferId}")
+    ResponseEntity<GetRecurringOfferDetailResponse> getRecurringOfferDetail(@PathVariable UUID recurringOfferId);
 
     @Operation(summary = "수요자의 정기 제안 신청 조회 API", description = "수요자가 작성한 정기 제안 신청서을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "수요자의 정기 제안 신청 조회 성공")
@@ -31,8 +36,19 @@ public interface RecurringOfferController {
     @Operation(summary = "(메인 페이지) 수요자의 정기 제안 추천 알림 조회", description = "메인 페이지에서 수요자에게 다음과 같은 조건에 맞는 정기 제안 알림을 조회합니다.<br>" +
             "1. 일정 리뷰 평점이 4점 이상<br>" +
             "2. 아직 정기 제안을 신청하지 않았음<br>" +
-            "3. 매칭이 종료된 일정")
+            "3. 매칭이 종료된 일정<br>" +
+            "RequestParam인 이유는 추후 JWT 등으로 인증 기능 구현 시 엔드포인트에 영향 받지 않고 ID를 전달하기 위함입니다.")
     @ApiResponse(responseCode = "200", description = "수요자에게 조건에 맞는 정기 제안 추천 알림 조회 성공")
     @GetMapping("/consumer/recommend")
-    ResponseEntity<List<RecommendRecurringOfferResponse>> getRecommendRecurringOfferForConsumer(@RequestParam UUID consumerId);
+    ResponseEntity<List<GetRecommendRecurringOfferResponse>> getRecommendRecurringOffersForConsumer(@RequestParam UUID consumerId);
+
+    @Operation(summary = "(메인 페이지) 수요자의 '읽지 않은' 정기 제안 상태 기반 알림 조회", description = "메인 페이지에서 수요자가 '읽지 않은(아직 해당 정기 제안의 상세 정보를 조회하지 않은)<br>" +
+            " 정기 제안 상태 기반 알림을 조회합니다.<br>" +
+            "1. 승인 대기(PENDING)<br>" +
+            "2. 승인 완료(APPROVED)<br>" +
+            "3. 거절(REJECTED)<br>" +
+            "RequestParam인 이유는 추후 JWT 등으로 인증 기능 구현 시 엔드포인트에 영향 받지 않고 ID를 전달하기 위함입니다.")
+    @ApiResponse(responseCode = "200", description = "수요자에게 조건에 맞는 정기 제안 추천 알림 조회 성공")
+    @GetMapping("/consumer/unread")
+    ResponseEntity<List<GetUnreadRecurringOfferResponse>> getUnreadRecurringOffersForConsumer(@RequestParam UUID consumerId);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/controller/RecurringOfferController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/controller/RecurringOfferController.java
@@ -2,9 +2,11 @@ package jaega.homecare.domain.recurringOffer.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jaega.homecare.domain.recurringOffer.dto.req.CreateRecurringOfferRequest;
 import jaega.homecare.domain.recurringOffer.dto.res.GetRecurringOfferResponse;
+import jaega.homecare.domain.recurringOffer.dto.res.RecommendRecurringOfferResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,7 +24,15 @@ public interface RecurringOfferController {
 
 
     @Operation(summary = "수요자의 정기 제안 신청 조회 API", description = "수요자가 작성한 정기 제안 신청서을 조회합니다.")
-    @ApiResponse(responseCode = "204", description = "수요자의 정기 제안 신청 조회 성공")
+    @ApiResponse(responseCode = "200", description = "수요자의 정기 제안 신청 조회 성공")
     @GetMapping("/consumer/{consumerId}")
     ResponseEntity<List<GetRecurringOfferResponse>> getRecurringOfferByConsumer(@PathVariable UUID consumerId);
+
+    @Operation(summary = "(메인 페이지) 수요자의 정기 제안 추천 알림 조회", description = "메인 페이지에서 수요자에게 다음과 같은 조건에 맞는 정기 제안 알림을 조회합니다.<br>" +
+            "1. 일정 리뷰 평점이 4점 이상<br>" +
+            "2. 아직 정기 제안을 신청하지 않았음<br>" +
+            "3. 매칭이 종료된 일정")
+    @ApiResponse(responseCode = "200", description = "수요자에게 조건에 맞는 정기 제안 추천 알림 조회 성공")
+    @GetMapping("/consumer/recommend")
+    ResponseEntity<List<RecommendRecurringOfferResponse>> getRecommendRecurringOfferForConsumer(@RequestParam UUID consumerId);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/controller/RecurringOfferController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/controller/RecurringOfferController.java
@@ -18,17 +18,23 @@ import java.util.UUID;
 @RequestMapping("/api/recurringOffer")
 public interface RecurringOfferController {
 
-    @Operation(summary = "정기 제안 신청 작성 API", description = "입력받은 정보로 수요자와 요양보호사 간의 정기 제안 신청을 생성합니다.")
+    @Operation(summary = "정기 제안 신청 작성 API", description = "입력받은 정보로 수요자와 요양보호사 간의 정기 제안 신청을 생성합니다.<br>" +
+            "정기 신청의 1회 서비스 소요 시간을 시간/분 단위로 입력받으며 다음과 같이 duration 입력하시면 됩니다." +
+            "ex) 3h30m : 3시간 30분, 3h : 3시간")
     @ApiResponse(responseCode = "204", description = "정기 제안 신청 작성 성공")
     @PostMapping
     ResponseEntity<Void> createRecurringOffer(@RequestBody CreateRecurringOfferRequest request);
 
-    @Operation(summary = "정기 제안 상세 조회 API", description = "작성된 정기 제안 신청서를 상세 조회합니다.")
+    @Operation(summary = "정기 제안 상세 조회 API", description = "작성된 정기 제안 신청서를 상세 조회합니다.<br>" +
+            "정기 신청의 1회 서비스 소요 시간이 다음과 같은 형식으로 조회됩니다." +
+            "ex) 3h30m : 3시간 30분, 3h : 3시간")
     @ApiResponse(responseCode = "200", description = "정기 제안 신청 상세 조회 성공")
     @GetMapping("/{recurringOfferId}")
     ResponseEntity<GetRecurringOfferDetailResponse> getRecurringOfferDetail(@PathVariable UUID recurringOfferId);
 
-    @Operation(summary = "수요자의 정기 제안 신청 조회 API", description = "수요자가 작성한 정기 제안 신청서을 조회합니다.")
+    @Operation(summary = "수요자의 정기 제안 신청 조회 API", description = "수요자가 작성한 정기 제안 신청서을 조회합니다." +
+            "정기 신청의 1회 서비스 소요 시간이 다음과 같은 형식으로 조회됩니다." +
+            "ex) 3h30m : 3시간 30분, 3h : 3시간")
     @ApiResponse(responseCode = "200", description = "수요자의 정기 제안 신청 조회 성공")
     @GetMapping("/consumer/{consumerId}")
     ResponseEntity<List<GetRecurringOfferResponse>> getRecurringOfferByConsumer(@PathVariable UUID consumerId);

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/controller/RecurringOfferControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/controller/RecurringOfferControllerImpl.java
@@ -22,6 +22,10 @@ public class RecurringOfferControllerImpl implements RecurringOfferController{
     private final RecurringOfferQueryService recurringOfferQueryService;
     private final RecurringOfferCommandService recurringOfferCommandService;
 
+    /**
+     *
+     * 정기 제안 신청 작성 API
+     */
     @Override
     public ResponseEntity<Void> createRecurringOffer(@RequestBody CreateRecurringOfferRequest request){
         recurringOfferCommandService.createRecurringOffer(request);
@@ -29,18 +33,30 @@ public class RecurringOfferControllerImpl implements RecurringOfferController{
         return ResponseEntity.noContent().build();
     }
 
+    /**
+     *
+     * 정기 제안 상세 조회 API
+     */
     @Override
     public ResponseEntity<GetRecurringOfferDetailResponse> getRecurringOfferDetail(@PathVariable UUID recurringOfferId){
         GetRecurringOfferDetailResponse response = recurringOfferQueryService.findRecurringOfferDetail(recurringOfferId);
         return ResponseEntity.ok(response);
     }
 
+    /**
+     *
+     * 수요자의 정기 제안 신청 조회 API
+     */
     @Override
     public ResponseEntity<List<GetRecurringOfferResponse>> getRecurringOfferByConsumer(@PathVariable UUID consumerId){
         List<GetRecurringOfferResponse> responses = recurringOfferQueryService.findRecurringOfferByConsumer(consumerId);
         return ResponseEntity.ok(responses);
     }
 
+    /**
+     *
+     * (메인 페이지) 수요자의 정기 제안 추천 알림 조회
+     */
     // TODO : RequestParam인 이유 -> JWT 등으로 인증 기능 구현 시 엔드포인트에 영향 받지 않고 ID를 전달하기 위함
     @Override
     public ResponseEntity<List<GetRecommendRecurringOfferResponse>> getRecommendRecurringOffersForConsumer(@RequestParam UUID consumerId){
@@ -48,6 +64,10 @@ public class RecurringOfferControllerImpl implements RecurringOfferController{
         return ResponseEntity.ok(recurringOfferResponses);
     }
 
+    /**
+     *
+     * (메인 페이지) 수요자의 '읽지 않은' 정기 제안 상태 기반 알림 조회
+     */
     // TODO : RequestParam인 이유 -> JWT 등으로 인증 기능 구현 시 엔드포인트에 영향 받지 않고 ID를 전달하기 위함
     @Override
     public ResponseEntity<List<GetUnreadRecurringOfferResponse>> getUnreadRecurringOffersForConsumer(@RequestParam UUID consumerId){

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/controller/RecurringOfferControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/controller/RecurringOfferControllerImpl.java
@@ -1,0 +1,38 @@
+package jaega.homecare.domain.recurringOffer.controller;
+
+import jaega.homecare.domain.recurringOffer.dto.req.CreateRecurringOfferRequest;
+import jaega.homecare.domain.recurringOffer.dto.res.GetRecurringOfferResponse;
+import jaega.homecare.domain.recurringOffer.service.command.RecurringOfferCommandService;
+import jaega.homecare.domain.recurringOffer.service.query.RecurringOfferQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/recurringOffer")
+public class RecurringOfferControllerImpl implements RecurringOfferController{
+
+    private final RecurringOfferQueryService recurringOfferQueryService;
+    private final RecurringOfferCommandService recurringOfferCommandService;
+
+    @Override
+    public ResponseEntity<Void> createRecurringOffer(@RequestBody CreateRecurringOfferRequest request){
+        recurringOfferCommandService.createRecurringOffer(request);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<List<GetRecurringOfferResponse>> getRecurringOfferByConsumer(@PathVariable UUID consumerId){
+        List<GetRecurringOfferResponse> responses = recurringOfferQueryService.findRecurringOfferByConsumer(consumerId);
+        return ResponseEntity.ok(responses);
+    }
+
+}

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/controller/RecurringOfferControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/controller/RecurringOfferControllerImpl.java
@@ -2,14 +2,12 @@ package jaega.homecare.domain.recurringOffer.controller;
 
 import jaega.homecare.domain.recurringOffer.dto.req.CreateRecurringOfferRequest;
 import jaega.homecare.domain.recurringOffer.dto.res.GetRecurringOfferResponse;
+import jaega.homecare.domain.recurringOffer.dto.res.RecommendRecurringOfferResponse;
 import jaega.homecare.domain.recurringOffer.service.command.RecurringOfferCommandService;
 import jaega.homecare.domain.recurringOffer.service.query.RecurringOfferQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
@@ -33,6 +31,13 @@ public class RecurringOfferControllerImpl implements RecurringOfferController{
     public ResponseEntity<List<GetRecurringOfferResponse>> getRecurringOfferByConsumer(@PathVariable UUID consumerId){
         List<GetRecurringOfferResponse> responses = recurringOfferQueryService.findRecurringOfferByConsumer(consumerId);
         return ResponseEntity.ok(responses);
+    }
+
+    // TODO : RequestParam인 이유 -> JWT 등으로 인증 기능 구현 시 엔드포인트에 영향 받지 않고 ID를 전달하기 위함
+    @Override
+    public ResponseEntity<List<RecommendRecurringOfferResponse>> getRecommendRecurringOfferForConsumer(@RequestParam UUID consumerId){
+        List<RecommendRecurringOfferResponse> recurringOfferResponses = recurringOfferQueryService.getRecommendedRecurringOffers(consumerId);
+        return ResponseEntity.ok(recurringOfferResponses);
     }
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/controller/RecurringOfferControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/controller/RecurringOfferControllerImpl.java
@@ -1,8 +1,10 @@
 package jaega.homecare.domain.recurringOffer.controller;
 
 import jaega.homecare.domain.recurringOffer.dto.req.CreateRecurringOfferRequest;
+import jaega.homecare.domain.recurringOffer.dto.res.GetRecurringOfferDetailResponse;
 import jaega.homecare.domain.recurringOffer.dto.res.GetRecurringOfferResponse;
-import jaega.homecare.domain.recurringOffer.dto.res.RecommendRecurringOfferResponse;
+import jaega.homecare.domain.recurringOffer.dto.res.GetRecommendRecurringOfferResponse;
+import jaega.homecare.domain.recurringOffer.dto.res.GetUnreadRecurringOfferResponse;
 import jaega.homecare.domain.recurringOffer.service.command.RecurringOfferCommandService;
 import jaega.homecare.domain.recurringOffer.service.query.RecurringOfferQueryService;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +30,12 @@ public class RecurringOfferControllerImpl implements RecurringOfferController{
     }
 
     @Override
+    public ResponseEntity<GetRecurringOfferDetailResponse> getRecurringOfferDetail(@PathVariable UUID recurringOfferId){
+        GetRecurringOfferDetailResponse response = recurringOfferQueryService.findRecurringOfferDetail(recurringOfferId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
     public ResponseEntity<List<GetRecurringOfferResponse>> getRecurringOfferByConsumer(@PathVariable UUID consumerId){
         List<GetRecurringOfferResponse> responses = recurringOfferQueryService.findRecurringOfferByConsumer(consumerId);
         return ResponseEntity.ok(responses);
@@ -35,9 +43,16 @@ public class RecurringOfferControllerImpl implements RecurringOfferController{
 
     // TODO : RequestParam인 이유 -> JWT 등으로 인증 기능 구현 시 엔드포인트에 영향 받지 않고 ID를 전달하기 위함
     @Override
-    public ResponseEntity<List<RecommendRecurringOfferResponse>> getRecommendRecurringOfferForConsumer(@RequestParam UUID consumerId){
-        List<RecommendRecurringOfferResponse> recurringOfferResponses = recurringOfferQueryService.getRecommendedRecurringOffers(consumerId);
+    public ResponseEntity<List<GetRecommendRecurringOfferResponse>> getRecommendRecurringOffersForConsumer(@RequestParam UUID consumerId){
+        List<GetRecommendRecurringOfferResponse> recurringOfferResponses = recurringOfferQueryService.findRecommendedRecurringOffers(consumerId);
         return ResponseEntity.ok(recurringOfferResponses);
+    }
+
+    // TODO : RequestParam인 이유 -> JWT 등으로 인증 기능 구현 시 엔드포인트에 영향 받지 않고 ID를 전달하기 위함
+    @Override
+    public ResponseEntity<List<GetUnreadRecurringOfferResponse>> getUnreadRecurringOffersForConsumer(@RequestParam UUID consumerId){
+        List<GetUnreadRecurringOfferResponse> responses = recurringOfferQueryService.findByUnreadRecurringOffers(consumerId);
+        return ResponseEntity.ok(responses);
     }
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/req/CreateRecurringOfferRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/req/CreateRecurringOfferRequest.java
@@ -24,9 +24,6 @@ public record CreateRecurringOfferRequest(
         @Schema(type = "string", format = "time", example = "18:00:00")
         LocalTime serviceEndTime,
 
-        @Schema(description = "시간/분을 초 단위로 직렬화합니다. 예: 3시간 30분 → 12600", example = "3h30m")
-        @JsonDeserialize(using = DurationDeserializer.class)
-        Integer duration,
         ServiceType serviceType
 ) {
 }

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/req/CreateRecurringOfferRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/req/CreateRecurringOfferRequest.java
@@ -1,8 +1,9 @@
 package jaega.homecare.domain.recurringOffer.dto.req;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jaega.homecare.domain.recurringOffer.entity.RecurringStatus;
 import jaega.homecare.domain.users.entity.ServiceType;
+import jaega.homecare.global.util.DurationDeserializer;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -23,6 +24,8 @@ public record CreateRecurringOfferRequest(
         @Schema(type = "string", format = "time", example = "18:00:00")
         LocalTime serviceEndTime,
 
+        @Schema(description = "시간/분을 초 단위로 직렬화합니다. 예: 3시간 30분 → 12600", example = "3h30m")
+        @JsonDeserialize(using = DurationDeserializer.class)
         Integer duration,
         ServiceType serviceType
 ) {

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/req/CreateRecurringOfferRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/req/CreateRecurringOfferRequest.java
@@ -1,0 +1,29 @@
+package jaega.homecare.domain.recurringOffer.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jaega.homecare.domain.recurringOffer.entity.RecurringStatus;
+import jaega.homecare.domain.users.entity.ServiceType;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Set;
+import java.util.UUID;
+
+public record CreateRecurringOfferRequest(
+        UUID caregiverId,
+        UUID consumerId,
+        Set<DayOfWeek> dayOfWeek,
+        LocalDate serviceStartDate,
+        LocalDate serviceEndDate,
+
+        @Schema(type = "string", format = "time", example = "09:00:00")
+        LocalTime serviceStartTime,
+
+        @Schema(type = "string", format = "time", example = "18:00:00")
+        LocalTime serviceEndTime,
+
+        Integer duration,
+        ServiceType serviceType
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/res/GetRecommendRecurringOfferResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/res/GetRecommendRecurringOfferResponse.java
@@ -6,7 +6,7 @@ import java.time.LocalTime;
 import java.util.Set;
 import java.util.UUID;
 
-public record RecommendRecurringOfferResponse(
+public record GetRecommendRecurringOfferResponse(
         UUID serviceMatchId,
         UUID caregiverId,
         LocalDate serviceDate,

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/res/GetRecommendRecurringOfferResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/res/GetRecommendRecurringOfferResponse.java
@@ -1,5 +1,7 @@
 package jaega.homecare.domain.recurringOffer.dto.res;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -10,7 +12,11 @@ public record GetRecommendRecurringOfferResponse(
         UUID serviceMatchId,
         UUID caregiverId,
         LocalDate serviceDate,
+
+        @Schema(type = "string", format = "time", example = "09:00:00")
         LocalTime serviceStartTime,
+
+        @Schema(type = "string", format = "time", example = "18:00:00")
         LocalTime serviceEndTime,
         Set<DayOfWeek> dayOfWeek
 ) {

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/res/GetRecurringOfferDetailResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/res/GetRecurringOfferDetailResponse.java
@@ -1,0 +1,25 @@
+package jaega.homecare.domain.recurringOffer.dto.res;
+
+import jaega.homecare.domain.recurringOffer.entity.RecurringStatus;
+import jaega.homecare.domain.users.entity.ServiceType;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Set;
+import java.util.UUID;
+
+public record GetRecurringOfferDetailResponse(
+        UUID recurringOfferId,
+        String caregiverName,
+        String consumer,
+        Set<DayOfWeek> dayOfWeek,
+        LocalDate serviceStartDate,
+        LocalDate serviceEndDate,
+        LocalTime serviceStartTime,
+        LocalTime serviceEndTime,
+        Integer duration,
+        ServiceType serviceType,
+        RecurringStatus recurringStatus
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/res/GetRecurringOfferDetailResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/res/GetRecurringOfferDetailResponse.java
@@ -1,7 +1,10 @@
 package jaega.homecare.domain.recurringOffer.dto.res;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jaega.homecare.domain.recurringOffer.entity.RecurringStatus;
 import jaega.homecare.domain.users.entity.ServiceType;
+import jaega.homecare.global.util.DurationSerializer;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -16,9 +19,17 @@ public record GetRecurringOfferDetailResponse(
         Set<DayOfWeek> dayOfWeek,
         LocalDate serviceStartDate,
         LocalDate serviceEndDate,
+
+        @Schema(type = "string", format = "time", example = "09:00:00")
         LocalTime serviceStartTime,
+
+        @Schema(type = "string", format = "time", example = "18:00:00")
         LocalTime serviceEndTime,
+
+        @Schema(example = "3h30m")
+        @JsonSerialize(using = DurationSerializer.class)
         Integer duration,
+
         ServiceType serviceType,
         RecurringStatus recurringStatus
 ) {

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/res/GetRecurringOfferResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/res/GetRecurringOfferResponse.java
@@ -1,0 +1,25 @@
+package jaega.homecare.domain.recurringOffer.dto.res;
+
+import jaega.homecare.domain.recurringOffer.entity.RecurringStatus;
+import jaega.homecare.domain.users.entity.ServiceType;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Set;
+import java.util.UUID;
+
+public record GetRecurringOfferResponse(
+        UUID recurringOfferId,
+        UUID caregiverId,
+        UUID consumerId,
+        Set<DayOfWeek> dayOfWeek,
+        LocalDate serviceStartDate,
+        LocalDate serviceEndDate,
+        LocalTime serviceStartTime,
+        LocalTime serviceEndTime,
+        Integer duration,
+        ServiceType serviceType,
+        RecurringStatus recurringStatus
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/res/GetRecurringOfferResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/res/GetRecurringOfferResponse.java
@@ -1,7 +1,10 @@
 package jaega.homecare.domain.recurringOffer.dto.res;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jaega.homecare.domain.recurringOffer.entity.RecurringStatus;
 import jaega.homecare.domain.users.entity.ServiceType;
+import jaega.homecare.global.util.DurationSerializer;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -16,9 +19,17 @@ public record GetRecurringOfferResponse(
         Set<DayOfWeek> dayOfWeek,
         LocalDate serviceStartDate,
         LocalDate serviceEndDate,
+
+        @Schema(type = "string", format = "time", example = "09:00:00")
         LocalTime serviceStartTime,
+
+        @Schema(type = "string", format = "time", example = "18:00:00")
         LocalTime serviceEndTime,
+
+        @Schema(example = "3h30m")
+        @JsonSerialize(using = DurationSerializer.class)
         Integer duration,
+
         ServiceType serviceType,
         RecurringStatus recurringStatus
 ) {

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/res/GetUnreadRecurringOfferResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/res/GetUnreadRecurringOfferResponse.java
@@ -1,5 +1,6 @@
 package jaega.homecare.domain.recurringOffer.dto.res;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jaega.homecare.domain.recurringOffer.entity.RecurringStatus;
 
 import java.time.LocalDate;
@@ -11,7 +12,11 @@ public record GetUnreadRecurringOfferResponse(
         String caregiverName,
         LocalDate serviceStartDate,
         LocalDate serviceEndDate,
+
+        @Schema(type = "string", format = "time", example = "09:00:00")
         LocalTime serviceStartTime,
+
+        @Schema(type = "string", format = "time", example = "18:00:00")
         LocalTime serviceEndTime,
         RecurringStatus recurringStatus
 ) {

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/res/GetUnreadRecurringOfferResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/res/GetUnreadRecurringOfferResponse.java
@@ -1,0 +1,18 @@
+package jaega.homecare.domain.recurringOffer.dto.res;
+
+import jaega.homecare.domain.recurringOffer.entity.RecurringStatus;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+public record GetUnreadRecurringOfferResponse(
+        UUID recurringOfferId,
+        String caregiverName,
+        LocalDate serviceStartDate,
+        LocalDate serviceEndDate,
+        LocalTime serviceStartTime,
+        LocalTime serviceEndTime,
+        RecurringStatus recurringStatus
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/res/RecommendRecurringOfferResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/dto/res/RecommendRecurringOfferResponse.java
@@ -1,0 +1,17 @@
+package jaega.homecare.domain.recurringOffer.dto.res;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Set;
+import java.util.UUID;
+
+public record RecommendRecurringOfferResponse(
+        UUID serviceMatchId,
+        UUID caregiverId,
+        LocalDate serviceDate,
+        LocalTime serviceStartTime,
+        LocalTime serviceEndTime,
+        Set<DayOfWeek> dayOfWeek
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/entity/RecurringOffer.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/entity/RecurringOffer.java
@@ -62,12 +62,18 @@ public class RecurringOffer extends BaseTimeEntity {
     @Column(name = "service_type", nullable = false)
     private ServiceType serviceType;        // 서비스 유형
 
-    private RecurringStatus recurringStatus;
+    @Column(name = "recurring_status")
+    private RecurringStatus recurringStatus = RecurringStatus.PENDING;
+
+    // TODO : 알림 확인 여부, 추후 이벤트 큐 구조 혹은 알림 기능 도입 시 해당 속성 삭제될 수 있음
+    @Column(name = "recurring_offer_unread", nullable = false)
+    private boolean recurringOfferUnread = true;
 
     @Builder
     public RecurringOffer(UUID recurringOfferId, Caregiver caregiver, Consumer consumer,
                           Set<DayOfWeek> dayOfWeek, LocalDate serviceStartDate, LocalDate serviceEndDate,
-                          LocalTime serviceStartTime, LocalTime serviceEndTime, Integer duration, ServiceType serviceType, RecurringStatus recurringStatus){
+                          LocalTime serviceStartTime, LocalTime serviceEndTime, Integer duration, ServiceType serviceType,
+                          RecurringStatus recurringStatus, boolean recurringOfferUnread){
         this.recurringOfferId = recurringOfferId;
         this.caregiver = caregiver;
         this.consumer = consumer;
@@ -78,12 +84,14 @@ public class RecurringOffer extends BaseTimeEntity {
         this.serviceEndTime = serviceEndTime;
         this.duration = duration;
         this.serviceType = serviceType;
-        this.recurringStatus = RecurringStatus.PENDING;
     }
 
     public void initializeRecurringOffer(UUID recurringOfferId){
         this.recurringOfferId = recurringOfferId;
     }
 
+    public void readRecurringOfferDetail(){
+        this.recurringOfferUnread = false;
+    }
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/entity/RecurringOffer.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/entity/RecurringOffer.java
@@ -55,9 +55,6 @@ public class RecurringOffer extends BaseTimeEntity {
     @JoinColumn(name = "service_end_time")
     private LocalTime serviceEndTime; // 서비스 종료 날짜
 
-    @Column(name = "duration", nullable = false)
-    private Integer duration;               // 1회 소요 시간
-
     @Enumerated(EnumType.STRING)
     @Column(name = "service_type", nullable = false)
     private ServiceType serviceType;        // 서비스 유형
@@ -72,7 +69,7 @@ public class RecurringOffer extends BaseTimeEntity {
     @Builder
     public RecurringOffer(UUID recurringOfferId, Caregiver caregiver, Consumer consumer,
                           Set<DayOfWeek> dayOfWeek, LocalDate serviceStartDate, LocalDate serviceEndDate,
-                          LocalTime serviceStartTime, LocalTime serviceEndTime, Integer duration, ServiceType serviceType,
+                          LocalTime serviceStartTime, LocalTime serviceEndTime, ServiceType serviceType,
                           RecurringStatus recurringStatus, boolean recurringOfferUnread){
         this.recurringOfferId = recurringOfferId;
         this.caregiver = caregiver;
@@ -82,7 +79,6 @@ public class RecurringOffer extends BaseTimeEntity {
         this.serviceEndDate = serviceEndDate;
         this.serviceStartTime = serviceStartTime;
         this.serviceEndTime = serviceEndTime;
-        this.duration = duration;
         this.serviceType = serviceType;
     }
 

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/entity/RecurringOffer.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/entity/RecurringOffer.java
@@ -38,8 +38,7 @@ public class RecurringOffer extends BaseTimeEntity {
 
     // 근무 가능 요일
     @ElementCollection(targetClass = DayOfWeek.class, fetch = FetchType.LAZY)
-    @CollectionTable(name = "recurring_offer_day_of_week",
-            joinColumns = @JoinColumn(name = "recurring_offer_id", referencedColumnName = "id"))
+    @CollectionTable(name = "recurring_offer_day_of_week", joinColumns = @JoinColumn(name = "recurring_offer_id"))
     @Enumerated(EnumType.STRING)
     @Column(name = "day_of_week")
     private Set<DayOfWeek> dayOfWeek = new HashSet<>();

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/entity/RecurringOffer.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/entity/RecurringOffer.java
@@ -1,0 +1,90 @@
+package jaega.homecare.domain.recurringOffer.entity;
+
+import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.domain.consumer.entity.Consumer;
+import jaega.homecare.domain.users.entity.ServiceType;
+import jaega.homecare.global.audit.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "recurring_offer")
+@NoArgsConstructor
+public class RecurringOffer extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(name = "recurring_offer_id", unique = true)
+    private UUID recurringOfferId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "caregiver_id")
+    private Caregiver caregiver;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "consumer_id")
+    private Consumer consumer;
+
+    // 근무 가능 요일
+    @ElementCollection(targetClass = DayOfWeek.class, fetch = FetchType.LAZY)
+    @CollectionTable(name = "recurring_offer_day_of_week",
+            joinColumns = @JoinColumn(name = "recurring_offer_id", referencedColumnName = "id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "day_of_week")
+    private Set<DayOfWeek> dayOfWeek = new HashSet<>();
+
+    @JoinColumn(name = "service_start_date")
+    private LocalDate serviceStartDate; // 서비스 시작 날짜
+
+    @JoinColumn(name = "service_end_date")
+    private LocalDate serviceEndDate; // 서비스 종료 날짜
+
+    @JoinColumn(name = "service_start_time")
+    private LocalTime serviceStartTime; // 서비스 시작 날짜
+
+    @JoinColumn(name = "service_end_time")
+    private LocalTime serviceEndTime; // 서비스 종료 날짜
+
+    @Column(name = "duration", nullable = false)
+    private Integer duration;               // 1회 소요 시간
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "service_type", nullable = false)
+    private ServiceType serviceType;        // 서비스 유형
+
+    private RecurringStatus recurringStatus;
+
+    @Builder
+    public RecurringOffer(UUID recurringOfferId, Caregiver caregiver, Consumer consumer,
+                          Set<DayOfWeek> dayOfWeek, LocalDate serviceStartDate, LocalDate serviceEndDate,
+                          LocalTime serviceStartTime, LocalTime serviceEndTime, Integer duration, ServiceType serviceType, RecurringStatus recurringStatus){
+        this.recurringOfferId = recurringOfferId;
+        this.caregiver = caregiver;
+        this.consumer = consumer;
+        this.dayOfWeek = dayOfWeek;
+        this.serviceStartDate = serviceStartDate;
+        this.serviceEndDate = serviceEndDate;
+        this.serviceStartTime = serviceStartTime;
+        this.serviceEndTime = serviceEndTime;
+        this.duration = duration;
+        this.serviceType = serviceType;
+        this.recurringStatus = RecurringStatus.PENDING;
+    }
+
+    public void initializeRecurringOffer(UUID recurringOfferId){
+        this.recurringOfferId = recurringOfferId;
+    }
+
+
+}

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/entity/RecurringStatus.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/entity/RecurringStatus.java
@@ -1,0 +1,7 @@
+package jaega.homecare.domain.recurringOffer.entity;
+
+public enum RecurringStatus{
+        PENDING,    // 승인 대기
+        APPROVED,   // 확정
+        REJECTED;   // 거절
+}

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/mapper/RecurringOfferMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/mapper/RecurringOfferMapper.java
@@ -3,7 +3,9 @@ package jaega.homecare.domain.recurringOffer.mapper;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.consumer.entity.Consumer;
 import jaega.homecare.domain.recurringOffer.dto.req.CreateRecurringOfferRequest;
+import jaega.homecare.domain.recurringOffer.dto.res.GetRecurringOfferDetailResponse;
 import jaega.homecare.domain.recurringOffer.dto.res.GetRecurringOfferResponse;
+import jaega.homecare.domain.recurringOffer.dto.res.GetUnreadRecurringOfferResponse;
 import jaega.homecare.domain.recurringOffer.entity.RecurringOffer;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -24,6 +26,7 @@ public interface RecurringOfferMapper {
     @Mapping(target = "serviceType", source = "request.serviceType")
     @Mapping(target = "recurringOfferId", ignore = true)
     @Mapping(target = "recurringStatus", ignore = true)
+    @Mapping(target = "recurringOfferUnread", ignore = true)
     RecurringOffer toEntity(CreateRecurringOfferRequest request, Caregiver caregiver, Consumer consumer);
 
     @Mapping(target = "caregiverId", source = "caregiver.caregiverId")
@@ -31,4 +34,13 @@ public interface RecurringOfferMapper {
     GetRecurringOfferResponse toGetResponseByConsumer(RecurringOffer recurringOffer);
 
     List<GetRecurringOfferResponse> toGetResponseByConsumer(List<RecurringOffer> recurringOffers);
+
+    @Mapping(target = "caregiverName", source = "caregiver.user.name")
+    @Mapping(target = "consumer", source = "consumer.user.name")
+    GetRecurringOfferDetailResponse toGetResponseByDetail(RecurringOffer recurringOffer);
+
+    @Mapping(target = "caregiverName", source = "caregiver.user.name")
+    GetUnreadRecurringOfferResponse toGetResponseByUnreadNotification(RecurringOffer recurringOffer);
+
+    List<GetUnreadRecurringOfferResponse> toGetResponseByUnreadNotification(List<RecurringOffer> recurringOffers);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/mapper/RecurringOfferMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/mapper/RecurringOfferMapper.java
@@ -1,0 +1,34 @@
+package jaega.homecare.domain.recurringOffer.mapper;
+
+import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.domain.consumer.entity.Consumer;
+import jaega.homecare.domain.recurringOffer.dto.req.CreateRecurringOfferRequest;
+import jaega.homecare.domain.recurringOffer.dto.res.GetRecurringOfferResponse;
+import jaega.homecare.domain.recurringOffer.entity.RecurringOffer;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface RecurringOfferMapper {
+
+    @Mapping(target = "caregiver", source = "caregiver")
+    @Mapping(target = "consumer", source = "consumer")
+    @Mapping(target = "dayOfWeek", source = "request.dayOfWeek")
+    @Mapping(target = "serviceStartDate", source = "request.serviceStartDate")
+    @Mapping(target = "serviceEndDate", source = "request.serviceEndDate")
+    @Mapping(target = "serviceStartTime", source = "request.serviceStartTime")
+    @Mapping(target = "serviceEndTime", source = "request.serviceEndTime")
+    @Mapping(target = "duration", source = "request.duration")
+    @Mapping(target = "serviceType", source = "request.serviceType")
+    @Mapping(target = "recurringOfferId", ignore = true)
+    @Mapping(target = "recurringStatus", ignore = true)
+    RecurringOffer toEntity(CreateRecurringOfferRequest request, Caregiver caregiver, Consumer consumer);
+
+    @Mapping(target = "caregiverId", source = "caregiver.caregiverId")
+    @Mapping(target = "consumerId", source = "consumer.consumerId")
+    GetRecurringOfferResponse toGetResponseByConsumer(RecurringOffer recurringOffer);
+
+    List<GetRecurringOfferResponse> toGetResponseByConsumer(List<RecurringOffer> recurringOffers);
+}

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/mapper/RecurringOfferMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/mapper/RecurringOfferMapper.java
@@ -22,24 +22,23 @@ public interface RecurringOfferMapper {
     @Mapping(target = "serviceEndDate", source = "request.serviceEndDate")
     @Mapping(target = "serviceStartTime", source = "request.serviceStartTime")
     @Mapping(target = "serviceEndTime", source = "request.serviceEndTime")
-    @Mapping(target = "duration", source = "request.duration")
     @Mapping(target = "serviceType", source = "request.serviceType")
     @Mapping(target = "recurringOfferId", ignore = true)
     @Mapping(target = "recurringStatus", ignore = true)
     @Mapping(target = "recurringOfferUnread", ignore = true)
     RecurringOffer toEntity(CreateRecurringOfferRequest request, Caregiver caregiver, Consumer consumer);
 
-    @Mapping(target = "caregiverId", source = "caregiver.caregiverId")
-    @Mapping(target = "consumerId", source = "consumer.consumerId")
-    GetRecurringOfferResponse toGetResponseByConsumer(RecurringOffer recurringOffer);
+    @Mapping(target = "caregiverId", source = "recurringOffer.caregiver.caregiverId")
+    @Mapping(target = "consumerId", source = "recurringOffer.consumer.consumerId")
+    @Mapping(target = "duration", source = "duration")
+    GetRecurringOfferResponse toGetResponseByConsumer(RecurringOffer recurringOffer, int duration);
 
-    List<GetRecurringOfferResponse> toGetResponseByConsumer(List<RecurringOffer> recurringOffers);
+    @Mapping(target = "caregiverName", source = "recurringOffer.caregiver.user.name")
+    @Mapping(target = "consumer", source = "recurringOffer.consumer.user.name")
+    @Mapping(target = "duration", source = "duration")
+    GetRecurringOfferDetailResponse toGetResponseByDetail(RecurringOffer recurringOffer, int duration);
 
-    @Mapping(target = "caregiverName", source = "caregiver.user.name")
-    @Mapping(target = "consumer", source = "consumer.user.name")
-    GetRecurringOfferDetailResponse toGetResponseByDetail(RecurringOffer recurringOffer);
-
-    @Mapping(target = "caregiverName", source = "caregiver.user.name")
+    @Mapping(target = "caregiverName", source = "recurringOffer.caregiver.user.name")
     GetUnreadRecurringOfferResponse toGetResponseByUnreadNotification(RecurringOffer recurringOffer);
 
     List<GetUnreadRecurringOfferResponse> toGetResponseByUnreadNotification(List<RecurringOffer> recurringOffers);

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/repository/RecurringOfferQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/repository/RecurringOfferQueryRepository.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 public class RecurringOfferQueryRepository {
     private final JPAQueryFactory queryFactory;
 
+    // 수요자의 아직 '읽지 않은'(정기 제안의 상세 정보) 정기 제안 알림용 조회
     public List<RecurringOffer> findUnreadRecurringOffersByConsumer(UUID consumerId) {
         QRecurringOffer recurringOffer = QRecurringOffer.recurringOffer;
 

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/repository/RecurringOfferQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/repository/RecurringOfferQueryRepository.java
@@ -1,0 +1,29 @@
+package jaega.homecare.domain.recurringOffer.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jaega.homecare.domain.recurringOffer.entity.QRecurringOffer;
+import jaega.homecare.domain.recurringOffer.entity.RecurringOffer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class RecurringOfferQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public List<RecurringOffer> findUnreadRecurringOffersByConsumer(UUID consumerId) {
+        QRecurringOffer recurringOffer = QRecurringOffer.recurringOffer;
+
+        return queryFactory
+                .selectFrom(recurringOffer)
+                .where(
+                        recurringOffer.consumer.consumerId.eq(consumerId),
+                        recurringOffer.recurringOfferUnread.eq(true)       // 알림 확인 안 한 것
+                )
+                .orderBy(recurringOffer.serviceStartDate.asc()) // 가장 임박한 건(오래된)부터 노출
+                .fetch();
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/repository/RecurringOfferRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/repository/RecurringOfferRepository.java
@@ -1,0 +1,15 @@
+package jaega.homecare.domain.recurringOffer.repository;
+
+import jaega.homecare.domain.consumer.entity.Consumer;
+import jaega.homecare.domain.recurringOffer.entity.RecurringOffer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface RecurringOfferRepository extends JpaRepository<RecurringOffer, Long> {
+    Optional<RecurringOffer> findByRecurringOfferId(UUID recurringOfferId);
+
+    List<RecurringOffer> findByConsumer(Consumer consumer);
+}

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/service/command/RecurringOfferCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/service/command/RecurringOfferCommandService.java
@@ -1,0 +1,39 @@
+package jaega.homecare.domain.recurringOffer.service.command;
+
+import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.domain.caregiver.repository.CaregiverRepository;
+import jaega.homecare.domain.caregiver.service.query.CaregiverQueryService;
+import jaega.homecare.domain.consumer.entity.Consumer;
+import jaega.homecare.domain.consumer.repository.ConsumerQueryRepository;
+import jaega.homecare.domain.consumer.repository.ConsumerRepository;
+import jaega.homecare.domain.consumer.service.query.ConsumerQueryService;
+import jaega.homecare.domain.recurringOffer.dto.req.CreateRecurringOfferRequest;
+import jaega.homecare.domain.recurringOffer.entity.RecurringOffer;
+import jaega.homecare.domain.recurringOffer.mapper.RecurringOfferMapper;
+import jaega.homecare.domain.recurringOffer.repository.RecurringOfferRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RecurringOfferCommandService {
+
+    private final RecurringOfferRepository recurringOfferRepository;
+    private final RecurringOfferMapper recurringOfferMapper;
+    private final CaregiverQueryService caregiverQueryService;
+    private final ConsumerQueryService consumerQueryService;
+
+    public void createRecurringOffer(CreateRecurringOfferRequest request){
+        Caregiver caregiver = caregiverQueryService.getCaregiver(request.caregiverId());
+        Consumer consumer = consumerQueryService.getConsumer(request.consumerId());
+
+        RecurringOffer recurringOffer = recurringOfferMapper.toEntity(request, caregiver, consumer);
+        recurringOffer.initializeRecurringOffer(UUID.randomUUID());
+        recurringOfferRepository.save(recurringOffer);
+
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/service/command/RecurringOfferCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/service/command/RecurringOfferCommandService.java
@@ -1,11 +1,8 @@
 package jaega.homecare.domain.recurringOffer.service.command;
 
 import jaega.homecare.domain.caregiver.entity.Caregiver;
-import jaega.homecare.domain.caregiver.repository.CaregiverRepository;
 import jaega.homecare.domain.caregiver.service.query.CaregiverQueryService;
 import jaega.homecare.domain.consumer.entity.Consumer;
-import jaega.homecare.domain.consumer.repository.ConsumerQueryRepository;
-import jaega.homecare.domain.consumer.repository.ConsumerRepository;
 import jaega.homecare.domain.consumer.service.query.ConsumerQueryService;
 import jaega.homecare.domain.recurringOffer.dto.req.CreateRecurringOfferRequest;
 import jaega.homecare.domain.recurringOffer.entity.RecurringOffer;
@@ -35,5 +32,9 @@ public class RecurringOfferCommandService {
         recurringOffer.initializeRecurringOffer(UUID.randomUUID());
         recurringOfferRepository.save(recurringOffer);
 
+    }
+
+    public void readRecurringOfferDetail(RecurringOffer recurringOffer){
+        recurringOffer.readRecurringOfferDetail();
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/service/query/RecurringOfferQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/service/query/RecurringOfferQueryService.java
@@ -16,6 +16,8 @@ import jaega.homecare.domain.serviceMatch.repository.ServiceMatchQueryRepository
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -40,13 +42,29 @@ public class RecurringOfferQueryService {
     public GetRecurringOfferDetailResponse findRecurringOfferDetail(UUID recurringOfferId){
         RecurringOffer recurringOffer = getRecurringOffer(recurringOfferId);
         recurringOfferCommandService.readRecurringOfferDetail(recurringOffer);
-        return recurringOfferMapper.toGetResponseByDetail(recurringOffer);
+
+        int durationInSeconds = calculateDurationInSeconds(
+                recurringOffer.getServiceStartTime(),
+                recurringOffer.getServiceEndTime()
+        );
+
+        return recurringOfferMapper.toGetResponseByDetail(recurringOffer, durationInSeconds);
     }
 
     public List<GetRecurringOfferResponse> findRecurringOfferByConsumer(UUID consumerId){
         Consumer consumer = consumerQueryService.getConsumer(consumerId);
         List<RecurringOffer> recurringOfferList = recurringOfferRepository.findByConsumer(consumer);
-        return recurringOfferMapper.toGetResponseByConsumer(recurringOfferList);
+
+        return recurringOfferList.stream()
+                .map(offer -> {
+                    int durationInSeconds = calculateDurationInSeconds(
+                            offer.getServiceStartTime(),
+                            offer.getServiceEndTime()
+                    );
+
+                    return recurringOfferMapper.toGetResponseByConsumer(offer, durationInSeconds);
+                })
+                .toList();
     }
 
     public List<GetRecommendRecurringOfferResponse> findRecommendedRecurringOffers(UUID consumerId) {
@@ -68,5 +86,12 @@ public class RecurringOfferQueryService {
         List<RecurringOffer> recurringOfferList = recurringOfferQueryRepository.findUnreadRecurringOffersByConsumer(consumerId);
 
         return recurringOfferMapper.toGetResponseByUnreadNotification(recurringOfferList);
+    }
+
+    /**
+     * 공통 duration 계산 메서드
+     */
+    private int calculateDurationInSeconds(LocalTime startTime, LocalTime endTime) {
+        return (int) Duration.between(startTime, endTime).getSeconds();
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/service/query/RecurringOfferQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/service/query/RecurringOfferQueryService.java
@@ -3,14 +3,18 @@ package jaega.homecare.domain.recurringOffer.service.query;
 import jaega.homecare.domain.consumer.entity.Consumer;
 import jaega.homecare.domain.consumer.service.query.ConsumerQueryService;
 import jaega.homecare.domain.recurringOffer.dto.res.GetRecurringOfferResponse;
+import jaega.homecare.domain.recurringOffer.dto.res.RecommendRecurringOfferResponse;
 import jaega.homecare.domain.recurringOffer.entity.RecurringOffer;
 import jaega.homecare.domain.recurringOffer.mapper.RecurringOfferMapper;
 import jaega.homecare.domain.recurringOffer.repository.RecurringOfferRepository;
+import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
+import jaega.homecare.domain.serviceMatch.repository.ServiceMatchQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.UUID;
 
 @Service
@@ -19,6 +23,7 @@ public class RecurringOfferQueryService {
 
     private final RecurringOfferMapper recurringOfferMapper;
     private final RecurringOfferRepository recurringOfferRepository;
+    private final ServiceMatchQueryRepository serviceMatchQueryRepository;
     private final ConsumerQueryService consumerQueryService;
 
     public RecurringOffer getRecurringOffer(UUID recurringOfferId){
@@ -30,5 +35,20 @@ public class RecurringOfferQueryService {
         Consumer consumer = consumerQueryService.getConsumer(consumerId);
         List<RecurringOffer> recurringOfferList = recurringOfferRepository.findByConsumer(consumer);
         return recurringOfferMapper.toGetResponseByConsumer(recurringOfferList);
+    }
+
+    public List<RecommendRecurringOfferResponse> getRecommendedRecurringOffers(UUID consumerId) {
+        List<ServiceMatch> matches = serviceMatchQueryRepository.findRecommendedServiceMatches(consumerId);
+
+        return matches.stream()
+                .map(sm -> new RecommendRecurringOfferResponse(
+                        sm.getServiceMatchId(),
+                        sm.getCaregiver().getCaregiverId(),
+                        sm.getServiceDate(),
+                        sm.getServiceStartTime(),
+                        sm.getServiceEndTime(),
+                        Set.of(sm.getServiceDate().getDayOfWeek())
+                ))
+                .toList();
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/service/query/RecurringOfferQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/service/query/RecurringOfferQueryService.java
@@ -1,0 +1,34 @@
+package jaega.homecare.domain.recurringOffer.service.query;
+
+import jaega.homecare.domain.consumer.entity.Consumer;
+import jaega.homecare.domain.consumer.service.query.ConsumerQueryService;
+import jaega.homecare.domain.recurringOffer.dto.res.GetRecurringOfferResponse;
+import jaega.homecare.domain.recurringOffer.entity.RecurringOffer;
+import jaega.homecare.domain.recurringOffer.mapper.RecurringOfferMapper;
+import jaega.homecare.domain.recurringOffer.repository.RecurringOfferRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RecurringOfferQueryService {
+
+    private final RecurringOfferMapper recurringOfferMapper;
+    private final RecurringOfferRepository recurringOfferRepository;
+    private final ConsumerQueryService consumerQueryService;
+
+    public RecurringOffer getRecurringOffer(UUID recurringOfferId){
+        return recurringOfferRepository.findByRecurringOfferId(recurringOfferId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 정기 제안서 입니다"));
+    }
+
+    public List<GetRecurringOfferResponse> findRecurringOfferByConsumer(UUID consumerId){
+        Consumer consumer = consumerQueryService.getConsumer(consumerId);
+        List<RecurringOffer> recurringOfferList = recurringOfferRepository.findByConsumer(consumer);
+        return recurringOfferMapper.toGetResponseByConsumer(recurringOfferList);
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/service/query/RecurringOfferQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/service/query/RecurringOfferQueryService.java
@@ -2,11 +2,15 @@ package jaega.homecare.domain.recurringOffer.service.query;
 
 import jaega.homecare.domain.consumer.entity.Consumer;
 import jaega.homecare.domain.consumer.service.query.ConsumerQueryService;
+import jaega.homecare.domain.recurringOffer.dto.res.GetRecurringOfferDetailResponse;
 import jaega.homecare.domain.recurringOffer.dto.res.GetRecurringOfferResponse;
-import jaega.homecare.domain.recurringOffer.dto.res.RecommendRecurringOfferResponse;
+import jaega.homecare.domain.recurringOffer.dto.res.GetUnreadRecurringOfferResponse;
+import jaega.homecare.domain.recurringOffer.dto.res.GetRecommendRecurringOfferResponse;
 import jaega.homecare.domain.recurringOffer.entity.RecurringOffer;
 import jaega.homecare.domain.recurringOffer.mapper.RecurringOfferMapper;
+import jaega.homecare.domain.recurringOffer.repository.RecurringOfferQueryRepository;
 import jaega.homecare.domain.recurringOffer.repository.RecurringOfferRepository;
+import jaega.homecare.domain.recurringOffer.service.command.RecurringOfferCommandService;
 import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
 import jaega.homecare.domain.serviceMatch.repository.ServiceMatchQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,12 +27,20 @@ public class RecurringOfferQueryService {
 
     private final RecurringOfferMapper recurringOfferMapper;
     private final RecurringOfferRepository recurringOfferRepository;
+    private final RecurringOfferQueryRepository recurringOfferQueryRepository;
     private final ServiceMatchQueryRepository serviceMatchQueryRepository;
+    private final RecurringOfferCommandService recurringOfferCommandService;
     private final ConsumerQueryService consumerQueryService;
 
     public RecurringOffer getRecurringOffer(UUID recurringOfferId){
         return recurringOfferRepository.findByRecurringOfferId(recurringOfferId)
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 정기 제안서 입니다"));
+    }
+
+    public GetRecurringOfferDetailResponse findRecurringOfferDetail(UUID recurringOfferId){
+        RecurringOffer recurringOffer = getRecurringOffer(recurringOfferId);
+        recurringOfferCommandService.readRecurringOfferDetail(recurringOffer);
+        return recurringOfferMapper.toGetResponseByDetail(recurringOffer);
     }
 
     public List<GetRecurringOfferResponse> findRecurringOfferByConsumer(UUID consumerId){
@@ -37,11 +49,11 @@ public class RecurringOfferQueryService {
         return recurringOfferMapper.toGetResponseByConsumer(recurringOfferList);
     }
 
-    public List<RecommendRecurringOfferResponse> getRecommendedRecurringOffers(UUID consumerId) {
+    public List<GetRecommendRecurringOfferResponse> findRecommendedRecurringOffers(UUID consumerId) {
         List<ServiceMatch> matches = serviceMatchQueryRepository.findRecommendedServiceMatches(consumerId);
 
         return matches.stream()
-                .map(sm -> new RecommendRecurringOfferResponse(
+                .map(sm -> new GetRecommendRecurringOfferResponse(
                         sm.getServiceMatchId(),
                         sm.getCaregiver().getCaregiverId(),
                         sm.getServiceDate(),
@@ -50,5 +62,11 @@ public class RecurringOfferQueryService {
                         Set.of(sm.getServiceDate().getDayOfWeek())
                 ))
                 .toList();
+    }
+
+    public List<GetUnreadRecurringOfferResponse> findByUnreadRecurringOffers(UUID consumerId){
+        List<RecurringOffer> recurringOfferList = recurringOfferQueryRepository.findUnreadRecurringOffersByConsumer(consumerId);
+
+        return recurringOfferMapper.toGetResponseByUnreadNotification(recurringOfferList);
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/repository/ServiceMatchQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/repository/ServiceMatchQueryRepository.java
@@ -167,7 +167,7 @@ public class ServiceMatchQueryRepository {
                                         .where(
                                                 caregiverCenter.center.centerId.eq(centerId)
                                                         .and(serviceMatch.serviceDate.eq(date))
-                                                        .and(serviceMatch.matchStatus.in(MatchStatus.PENDING, MatchStatus.COMPLETED))
+                                                        .and(serviceMatch.matchStatus.in(MatchStatus.PENDING, MatchStatus.CONFIRMED))
                                         ), "assignedCaregivers"
                         ),
                         ExpressionUtils.as( // 매칭이 있으나 오늘이 아닌 요양보호사 수 조회

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/repository/ServiceMatchQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/repository/ServiceMatchQueryRepository.java
@@ -12,9 +12,12 @@ import jaega.homecare.domain.caregiverCenter.entity.CaregiverStatus;
 import jaega.homecare.domain.caregiverCenter.entity.QCaregiverCenter;
 import jaega.homecare.domain.center.dto.res.GetCaregiverMatchesByMonth;
 import jaega.homecare.domain.consumer.entity.QConsumer;
+import jaega.homecare.domain.recurringOffer.entity.QRecurringOffer;
+import jaega.homecare.domain.review.entity.QReview;
 import jaega.homecare.domain.serviceMatch.dto.res.GetServiceMatchByCenterResponse;
 import jaega.homecare.domain.serviceMatch.entity.MatchStatus;
 import jaega.homecare.domain.serviceMatch.entity.QServiceMatch;
+import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
 import jaega.homecare.domain.serviceRequest.entity.QServiceRequest;
 import jaega.homecare.domain.settlement.dto.res.WorkPlaceDistribution;
 import jaega.homecare.domain.users.entity.QUser;
@@ -304,5 +307,39 @@ public class ServiceMatchQueryRepository {
                         base.matchStatus()
                 ))
                 .toList();
+    }
+
+    /**
+     * 추천 정기 제안용 ServiceMatch 조회
+     *
+     * - RecurringOffer 정기 제안 추천을 위해 사용
+     *
+     * 조회 조건:
+     * - 리뷰 점수 4점 이상
+     * - 매칭 상태가 CONFIRMED
+     * - 아직 정기 제안이 신청되지 않은 일정
+     * - 특정 소비자 기준 필터 적용
+     */
+    public List<ServiceMatch> findRecommendedServiceMatches(UUID consumerId) {
+        QServiceMatch serviceMatch = QServiceMatch.serviceMatch;
+        QReview review = QReview.review;
+        QRecurringOffer recurringOffer = QRecurringOffer.recurringOffer;
+
+        return queryFactory
+                .select(serviceMatch)
+                .from(serviceMatch)
+                .join(serviceMatch.serviceRequest)
+                .join(serviceMatch.serviceRequest.consumer)
+                .leftJoin(review).on(review.serviceMatch.eq(serviceMatch))
+                .leftJoin(recurringOffer)
+                .on(recurringOffer.consumer.eq(serviceMatch.serviceRequest.consumer)
+                        .and(recurringOffer.caregiver.eq(serviceMatch.caregiver)))
+                .where(
+                        serviceMatch.serviceRequest.consumer.consumerId.eq(consumerId), // 특정 소비자
+                        serviceMatch.matchStatus.eq(MatchStatus.COMPLETED),             // 매칭 완료 상태
+                        review.reviewScore.goe(4.0),                                     // 리뷰 점수 4 이상
+                        recurringOffer.id.isNull()                                        // 아직 정기 제안 없음
+                )
+                .fetch();
     }
 }

--- a/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
+++ b/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
@@ -132,9 +132,9 @@ public class DummyDataService {
             serviceTypes.add(ServiceType.values()[random.nextInt(ServiceType.values().length)]);
         }
 
-        Set<DayOfWeek> daysOff = new HashSet<>();
+        Set<DayOfWeek> dayOfWeek = new HashSet<>();
         if (random.nextBoolean()) {
-            daysOff.add(DayOfWeek.values()[random.nextInt(7)]);
+            dayOfWeek.add(DayOfWeek.values()[random.nextInt(7)]);
         }
 
         Caregiver caregiver = Caregiver.builder()
@@ -145,7 +145,7 @@ public class DummyDataService {
                 .address("서울시 송파구 올림픽로 " + index)
                 .location(new Location(37.514 + random.nextDouble() * 0.1, 86.106 + random.nextDouble() * 0.1))
                 .serviceTypes(serviceTypes)
-                .daysOff(daysOff)
+                .dayOfWeek(dayOfWeek)
                 .build();
         caregiverRepository.save(caregiver);
 

--- a/homecare/src/main/java/jaega/homecare/global/util/DurationDeserializer.java
+++ b/homecare/src/main/java/jaega/homecare/global/util/DurationDeserializer.java
@@ -1,0 +1,28 @@
+package jaega.homecare.global.util;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+public class DurationDeserializer extends JsonDeserializer<Integer> {
+    @Override
+    public Integer deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        String durationStr = p.getText().trim();
+        int hours = 0;
+        int minutes = 0;
+
+        if (durationStr.contains("h")) {
+            String[] parts = durationStr.split("h");
+            hours = Integer.parseInt(parts[0].trim());
+            if (parts.length > 1 && parts[1].contains("m")) {
+                minutes = Integer.parseInt(parts[1].replace("m", "").trim());
+            }
+        } else if (durationStr.contains("m")) {
+            minutes = Integer.parseInt(durationStr.replace("m", "").trim());
+        }
+
+        return hours * 3600 + minutes * 60;
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/global/util/DurationSerializer.java
+++ b/homecare/src/main/java/jaega/homecare/global/util/DurationSerializer.java
@@ -1,0 +1,23 @@
+package jaega.homecare.global.util;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+public class DurationSerializer extends JsonSerializer<Integer> {
+
+    @Override
+    public void serialize(Integer value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        int hours = value / 3600;
+        int minutes = (value % 3600) / 60;
+
+        StringBuilder sb = new StringBuilder();
+        if (hours > 0) sb.append(hours).append("h");
+        if (minutes > 0) sb.append(minutes).append("m");
+        if (sb.isEmpty()) sb.append("0m"); // 0초인 경우 처리
+
+        gen.writeString(sb.toString());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #30 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 1. 기획 변경에 따라 요양보호사의 days_off(휴무일)을 dayOfWeek(요일)로 변경했습니다.

### 2. 수요자의 정기 제안 작성 api를 구현했습니다.

### 3. 수요자의 메인 페이지용 정기 제안 조회 api를 구현했습니다.
- 정기 제안 추천 api 구현 ( 일정 리뷰의 평점이 4점 이상이고 아직 정기 제안이 신청되지 않은 경우)
- 정기 제안 상태 변화 기반 알림 api 구현 ( 아직 정기 제안의 '상세 정보'를 읽지 않은 정기 제안의 상태 기반 알림 조회)

### 4. 정기 제안의 '1회 서비스 소요 시간'은 시간/분에 따라 역/직렬화했습니다.
- '1회 서비스 소요 시간'(duration)은 프론트에서 시간/분으로 관리하도록 '3h 30m', '4h' 형식으로 입력값/리턴값을 구성했습니다.


### 스크린샷 (선택)

**예시 입력값**
<img width="1000" height="424" alt="image" src="https://github.com/user-attachments/assets/e86eb02b-9e5c-462d-bb44-6ea82a8ad5f2" />


**예시 리턴값**
<img width="938" height="502" alt="image" src="https://github.com/user-attachments/assets/8848e667-79f6-4c0e-be84-297619a9ddec" />


<br>

## 💬리뷰 요구사항(선택)

### 요양보호사, 정기 제안 도메인의 '요일' 속성의 이름을 다음과 같이 변경했는데 적합한 네이밍일까요?
두 도메인은 같은 요일을 조회하기 때문에 `@ElementCollection`을 이용하여 같은 테이블을 조회하고자 했습니다.
그러나, 각 두 도메인은 외래키로 연결되어서 같은 테이블로 매핑하면 db 상에서 null 예외가 발생합니다.
그래서 요양보호사는 `caregiver_day_of_week`, 정기 제안은 'recurring_offer_day_of_week'로 변경했는데 적합한 네이밍일까요?
일단 두 속성의 entity에선 day_of_week로 각각 명시해두었습니다!

### RecurringOffer(정기 제안) 엔티티에서 각 속성의 네이밍이 괜찮으신지 검토 부탁드립니다!
제가 신경쓰이는 속성은 다음 부분입니다!
`serviceStartDate`, `serviceEndDate`, serviceStartTime`, `serviceEndTime`
정기 제안의 시작, 종료 날짜/시간이라 `recurringOffer(Start/End)(Date/Time)`으로 전환하는 게 괜찮은지 여쭤봅니다 !! 
혹시 다른 속성명이 더 괜찮다거나 기존의 속성명이 더 괜찮으시다면 의견 부탁드립니다! 

### '1회 서비스 소요 시간'은 필요없는 속성일까요,,?
구현을 다하고 생각해보니 '1회 서비스 소요 시간' = duration은 입력값에서 가능한 서비스 시간/종료 날짜를 입력하면
프론트에서 그에 따라 서비스 소요 시간을 계산만 하면 되니 백엔드에선 굳이 다룰 필요가 없는 속성인지 여쭤봅니다!
ex : 시작 시간 = 13:00, 종료 시간 = 16:30 ->  || 16:30 - 13:00 - > 3시간 반