### PR TITLE
[#33] 요양보호사 회원가입, 선호(근무) 조건 관련 API 구현

### DIFF
--- a/homecare/src/main/java/jaega/homecare/domain/blacklist/controller/BlacklistController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/blacklist/controller/BlacklistController.java
@@ -1,10 +1,10 @@
-package jaega.homecare.domain.Blacklist.controller;
+package jaega.homecare.domain.blacklist.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jaega.homecare.domain.Blacklist.dto.req.CreateBlacklistByConsumerRequest;
-import jaega.homecare.domain.Blacklist.dto.res.GetBlacklistByConsumerResponse;
+import jaega.homecare.domain.blacklist.dto.req.CreateBlacklistByConsumerRequest;
+import jaega.homecare.domain.blacklist.dto.res.GetBlacklistByConsumerResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/homecare/src/main/java/jaega/homecare/domain/blacklist/controller/BlacklistControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/blacklist/controller/BlacklistControllerImpl.java
@@ -1,9 +1,9 @@
-package jaega.homecare.domain.Blacklist.controller;
+package jaega.homecare.domain.blacklist.controller;
 
-import jaega.homecare.domain.Blacklist.dto.req.CreateBlacklistByConsumerRequest;
-import jaega.homecare.domain.Blacklist.dto.res.GetBlacklistByConsumerResponse;
-import jaega.homecare.domain.Blacklist.service.command.BlacklistCommandService;
-import jaega.homecare.domain.Blacklist.service.query.BlacklistQueryService;
+import jaega.homecare.domain.blacklist.dto.req.CreateBlacklistByConsumerRequest;
+import jaega.homecare.domain.blacklist.dto.res.GetBlacklistByConsumerResponse;
+import jaega.homecare.domain.blacklist.service.command.BlacklistCommandService;
+import jaega.homecare.domain.blacklist.service.query.BlacklistQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/homecare/src/main/java/jaega/homecare/domain/blacklist/dto/req/CreateBlacklistByConsumerRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/blacklist/dto/req/CreateBlacklistByConsumerRequest.java
@@ -1,4 +1,4 @@
-package jaega.homecare.domain.Blacklist.dto.req;
+package jaega.homecare.domain.blacklist.dto.req;
 
 import java.util.UUID;
 

--- a/homecare/src/main/java/jaega/homecare/domain/blacklist/dto/res/GetBlacklistByConsumerResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/blacklist/dto/res/GetBlacklistByConsumerResponse.java
@@ -1,4 +1,4 @@
-package jaega.homecare.domain.Blacklist.dto.res;
+package jaega.homecare.domain.blacklist.dto.res;
 
 import java.util.UUID;
 

--- a/homecare/src/main/java/jaega/homecare/domain/blacklist/entity/Blacklist.java
+++ b/homecare/src/main/java/jaega/homecare/domain/blacklist/entity/Blacklist.java
@@ -1,4 +1,4 @@
-package jaega.homecare.domain.Blacklist.entity;
+package jaega.homecare.domain.blacklist.entity;
 
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.consumer.entity.Consumer;

--- a/homecare/src/main/java/jaega/homecare/domain/blacklist/mapper/BlacklistMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/blacklist/mapper/BlacklistMapper.java
@@ -1,8 +1,8 @@
-package jaega.homecare.domain.Blacklist.mapper;
+package jaega.homecare.domain.blacklist.mapper;
 
-import jaega.homecare.domain.Blacklist.dto.req.CreateBlacklistByConsumerRequest;
-import jaega.homecare.domain.Blacklist.dto.res.GetBlacklistByConsumerResponse;
-import jaega.homecare.domain.Blacklist.entity.Blacklist;
+import jaega.homecare.domain.blacklist.dto.req.CreateBlacklistByConsumerRequest;
+import jaega.homecare.domain.blacklist.dto.res.GetBlacklistByConsumerResponse;
+import jaega.homecare.domain.blacklist.entity.Blacklist;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.consumer.entity.Consumer;
 import org.mapstruct.Mapper;

--- a/homecare/src/main/java/jaega/homecare/domain/blacklist/repository/BlacklistRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/blacklist/repository/BlacklistRepository.java
@@ -1,6 +1,6 @@
-package jaega.homecare.domain.Blacklist.repository;
+package jaega.homecare.domain.blacklist.repository;
 
-import jaega.homecare.domain.Blacklist.entity.Blacklist;
+import jaega.homecare.domain.blacklist.entity.Blacklist;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/homecare/src/main/java/jaega/homecare/domain/blacklist/service/command/BlacklistCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/blacklist/service/command/BlacklistCommandService.java
@@ -1,12 +1,12 @@
-package jaega.homecare.domain.Blacklist.service.command;
+package jaega.homecare.domain.blacklist.service.command;
 
-import jaega.homecare.domain.Blacklist.dto.req.CreateBlacklistByConsumerRequest;
-import jaega.homecare.domain.Blacklist.entity.Blacklist;
-import jaega.homecare.domain.Blacklist.mapper.BlacklistMapper;
-import jaega.homecare.domain.Blacklist.repository.BlacklistRepository;
+import jaega.homecare.domain.blacklist.dto.req.CreateBlacklistByConsumerRequest;
+import jaega.homecare.domain.blacklist.entity.Blacklist;
+import jaega.homecare.domain.blacklist.mapper.BlacklistMapper;
+import jaega.homecare.domain.blacklist.repository.BlacklistRepository;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.caregiver.service.query.CaregiverQueryService;
-import jaega.homecare.domain.Blacklist.service.query.BlacklistQueryService;
+import jaega.homecare.domain.blacklist.service.query.BlacklistQueryService;
 import jaega.homecare.domain.consumer.entity.Consumer;
 import jaega.homecare.domain.consumer.service.query.ConsumerQueryService;
 import jakarta.transaction.Transactional;

--- a/homecare/src/main/java/jaega/homecare/domain/blacklist/service/query/BlacklistQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/blacklist/service/query/BlacklistQueryService.java
@@ -1,9 +1,9 @@
-package jaega.homecare.domain.Blacklist.service.query;
+package jaega.homecare.domain.blacklist.service.query;
 
-import jaega.homecare.domain.Blacklist.dto.res.GetBlacklistByConsumerResponse;
-import jaega.homecare.domain.Blacklist.entity.Blacklist;
-import jaega.homecare.domain.Blacklist.mapper.BlacklistMapper;
-import jaega.homecare.domain.Blacklist.repository.BlacklistRepository;
+import jaega.homecare.domain.blacklist.dto.res.GetBlacklistByConsumerResponse;
+import jaega.homecare.domain.blacklist.entity.Blacklist;
+import jaega.homecare.domain.blacklist.mapper.BlacklistMapper;
+import jaega.homecare.domain.blacklist.repository.BlacklistRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverController.java
@@ -6,6 +6,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jaega.homecare.domain.caregiver.dto.req.CaregiverSignupRequest;
 import jaega.homecare.domain.caregiver.dto.req.ChoiceCaregiverCenterRequest;
+import jaega.homecare.domain.caregiver.dto.res.GetCaregiverSignupResponse;
+import jaega.homecare.domain.caregiver.dto.res.GetCaregiverVerifiedStatusResponse;
 import jaega.homecare.domain.caregiver.dto.res.SelectableCaregiverCenter;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,7 +23,13 @@ public interface CaregiverController {
     @Operation(summary = "요양보호사 회원가입 API", description = "입력받은 정보로 요양보호사의 회원가입을 진행합니다.")
     @ApiResponse(responseCode = "204", description = "요양보호사의 회원가입 성공")
     @PostMapping
-    ResponseEntity<Void> signupCaregiver(@RequestBody CaregiverSignupRequest request);
+    ResponseEntity<GetCaregiverSignupResponse> signupCaregiver(@RequestBody CaregiverSignupRequest request);
+
+    @Operation(summary = "요양보호사 승인 상태 조회 API", description = "회원가입 후, 기관 선택으로 이동하기 전 승인 검증을 위해 승인 상태를 조회합니다.<br>" +
+            "RequestParam으로 한 이유는, 추후 JWT 인증 로직 구현 시 대체를 편하게 하기 위함입니다.")
+    @ApiResponse(responseCode = "200", description = "요양보호사의 승인 상태 조회 성공")
+    @GetMapping("/verified")
+    ResponseEntity<GetCaregiverVerifiedStatusResponse> getCaregiverVerifiedStatus(@RequestParam UUID caregiverId);
 
     @Operation(
             summary = "활성화된 센터 목록 조회",

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jaega.homecare.domain.caregiver.dto.req.CaregiverSignupRequest;
 import jaega.homecare.domain.caregiver.dto.req.ChoiceCaregiverCenterRequest;
 import jaega.homecare.domain.caregiver.dto.res.SelectableCaregiverCenter;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,11 @@ import java.util.UUID;
 @Tag(name = "Caregiver", description = "Caregiver 서비스 API")
 @RequestMapping("/api/caregiver")
 public interface CaregiverController {
+
+    @Operation(summary = "요양보호사 회원가입 API", description = "입력받은 정보로 요양보호사의 회원가입을 진행합니다.")
+    @ApiResponse(responseCode = "204", description = "요양보호사의 회원가입 성공")
+    @PostMapping
+    ResponseEntity<Void> signupCaregiver(@RequestBody CaregiverSignupRequest request);
 
     @Operation(
             summary = "활성화된 센터 목록 조회",

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverControllerImpl.java
@@ -1,7 +1,9 @@
 package jaega.homecare.domain.caregiver.controller;
 
+import jaega.homecare.domain.caregiver.dto.req.CaregiverSignupRequest;
 import jaega.homecare.domain.caregiver.dto.req.ChoiceCaregiverCenterRequest;
 import jaega.homecare.domain.caregiver.dto.res.SelectableCaregiverCenter;
+import jaega.homecare.domain.caregiver.service.command.CaregiverCommandService;
 import jaega.homecare.domain.caregiverCenter.entity.CaregiverCenter;
 import jaega.homecare.domain.caregiverCenter.service.query.CaregiverCenterQueryService;
 import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
@@ -23,6 +25,17 @@ public class CaregiverControllerImpl implements CaregiverController {
     private final SettlementCommandService settlementCommandService;
     private final ServiceMatchQueryService serviceMatchQueryService;
     private final CaregiverCenterQueryService caregiverCenterQueryService;
+    private final CaregiverCommandService caregiverCommandService;
+
+    /**
+     *
+     * 요양보호사 회원가입
+     */
+    @Override
+    public ResponseEntity<Void> signupCaregiver(@RequestBody CaregiverSignupRequest request){
+        caregiverCommandService.signupCaregiver(request);
+        return ResponseEntity.noContent().build();
+    }
 
     /**
      *

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverControllerImpl.java
@@ -45,6 +45,7 @@ public class CaregiverControllerImpl implements CaregiverController {
      *
      * 요양보호사 승인 상태 조회
      */
+    // TODO : 인증 기능 구현 시 다른 페이지로 이동 못하도록 CORS 도입 고려
     @Override
     public ResponseEntity<GetCaregiverVerifiedStatusResponse> getCaregiverVerifiedStatus(@RequestParam UUID caregiverId){
         GetCaregiverVerifiedStatusResponse response = caregiverQueryService.getCaregiverVerifiedStatus(caregiverId);

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverControllerImpl.java
@@ -2,8 +2,11 @@ package jaega.homecare.domain.caregiver.controller;
 
 import jaega.homecare.domain.caregiver.dto.req.CaregiverSignupRequest;
 import jaega.homecare.domain.caregiver.dto.req.ChoiceCaregiverCenterRequest;
+import jaega.homecare.domain.caregiver.dto.res.GetCaregiverSignupResponse;
+import jaega.homecare.domain.caregiver.dto.res.GetCaregiverVerifiedStatusResponse;
 import jaega.homecare.domain.caregiver.dto.res.SelectableCaregiverCenter;
 import jaega.homecare.domain.caregiver.service.command.CaregiverCommandService;
+import jaega.homecare.domain.caregiver.service.query.CaregiverQueryService;
 import jaega.homecare.domain.caregiverCenter.entity.CaregiverCenter;
 import jaega.homecare.domain.caregiverCenter.service.query.CaregiverCenterQueryService;
 import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
@@ -26,16 +29,29 @@ public class CaregiverControllerImpl implements CaregiverController {
     private final ServiceMatchQueryService serviceMatchQueryService;
     private final CaregiverCenterQueryService caregiverCenterQueryService;
     private final CaregiverCommandService caregiverCommandService;
+    private final CaregiverQueryService caregiverQueryService;
 
     /**
      *
      * 요양보호사 회원가입
      */
     @Override
-    public ResponseEntity<Void> signupCaregiver(@RequestBody CaregiverSignupRequest request){
-        caregiverCommandService.signupCaregiver(request);
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<GetCaregiverSignupResponse> signupCaregiver(@RequestBody CaregiverSignupRequest request){
+        GetCaregiverSignupResponse response = caregiverCommandService.signupCaregiver(request);
+        return ResponseEntity.ok(response);
     }
+
+    /**
+     *
+     * 요양보호사 승인 상태 조회
+     */
+    @Override
+    public ResponseEntity<GetCaregiverVerifiedStatusResponse> getCaregiverVerifiedStatus(@RequestParam UUID caregiverId){
+        GetCaregiverVerifiedStatusResponse response = caregiverQueryService.getCaregiverVerifiedStatus(caregiverId);
+        return ResponseEntity.ok(response);
+    }
+
+    // 센터
 
     /**
      *

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/dto/req/CaregiverCreateRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/dto/req/CaregiverCreateRequest.java
@@ -1,0 +1,30 @@
+package jaega.homecare.domain.caregiver.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jaega.homecare.domain.caregiver.entity.KoreanProficiency;
+import jaega.homecare.domain.caregiver.entity.VerifiedStatus;
+import jaega.homecare.domain.users.entity.ServiceType;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.Set;
+
+public record CaregiverCreateRequest(
+        @Schema(type = "string", format = "time", example = "09:00:00")
+        LocalTime availableStartTime,
+
+        @Schema(type = "string", format = "time", example = "18:00:00")
+        LocalTime availableEndTime,
+        String address,
+        Set<ServiceType> serviceTypes,
+        Set<DayOfWeek> dayOfWeek,
+
+        @Schema(type = "integer", example = "5", description = "경력(년 단위)")
+        Integer career,
+
+        KoreanProficiency koreanProficiency,
+        boolean isAccompanyOuting,
+        String selfIntroduction,
+        VerifiedStatus verifiedStatus
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/dto/req/CaregiverSignupRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/dto/req/CaregiverSignupRequest.java
@@ -1,0 +1,10 @@
+package jaega.homecare.domain.caregiver.dto.req;
+
+import jaega.homecare.domain.users.dto.req.UserCreateRequest;
+
+public record CaregiverSignupRequest(
+        UserCreateRequest user,
+        CaregiverCreateRequest caregiver,
+        CreateCertificationRequest certification
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/dto/req/CreateCertificationRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/dto/req/CreateCertificationRequest.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.util.UUID;
 
 public record CreateCertificationRequest(
-        UUID caregiverId,
         String certificationNumber,
         LocalDate certificationDate
 ) {

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/dto/res/GetCaregiverSignupResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/dto/res/GetCaregiverSignupResponse.java
@@ -1,0 +1,8 @@
+package jaega.homecare.domain.caregiver.dto.res;
+
+import java.util.UUID;
+
+public record GetCaregiverSignupResponse(
+        UUID caregiverId
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/dto/res/GetCaregiverVerifiedStatusResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/dto/res/GetCaregiverVerifiedStatusResponse.java
@@ -1,0 +1,11 @@
+package jaega.homecare.domain.caregiver.dto.res;
+
+import jaega.homecare.domain.caregiver.entity.VerifiedStatus;
+
+import java.util.UUID;
+
+public record GetCaregiverVerifiedStatusResponse(
+        UUID caregiverId,
+        VerifiedStatus verifiedStatus
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
@@ -1,7 +1,5 @@
 package jaega.homecare.domain.caregiver.entity;
 
-import jaega.homecare.domain.center.dto.req.CreateCaregiverProfileRequest;
-import jaega.homecare.domain.users.entity.ServiceType;
 import jaega.homecare.domain.users.entity.User;
 import jaega.homecare.global.audit.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -9,10 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.DayOfWeek;
 import java.time.LocalTime;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.UUID;
 
 @Entity
@@ -42,13 +37,6 @@ public class Caregiver extends BaseTimeEntity {
     @Column(name = "address")
     private String address;
 
-    // 서비스 유형 (다중 선택 가능)
-    @ElementCollection(targetClass = ServiceType.class, fetch = FetchType.LAZY)
-    @CollectionTable(name = "service_type", joinColumns = @JoinColumn(name = "caregiver_id"))
-    @Enumerated(EnumType.STRING)
-    @Column(name = "service_type")
-    private Set<ServiceType> serviceTypes = new HashSet<>();
-
     @Column(name = "career")
     private Integer career;
 
@@ -67,14 +55,13 @@ public class Caregiver extends BaseTimeEntity {
 
     @Builder
     public Caregiver(UUID caregiverId, User user, LocalTime availableStartTime, LocalTime availableEndTime,
-                     String address, Set<ServiceType> serviceTypes, Integer career,
+                     String address, Integer career,
                      KoreanProficiency koreanProficiency, boolean isAccompanyOuting, String selfIntroduction, VerifiedStatus verifiedStatus) {
         this.caregiverId = caregiverId;
         this.user = user;
         this.availableStartTime = availableStartTime;
         this.availableEndTime = availableEndTime;
         this.address = address;
-        this.serviceTypes = serviceTypes;
         this.career = career;
         this.koreanProficiency = koreanProficiency;
         this.isAccompanyOuting = isAccompanyOuting;

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
@@ -1,7 +1,6 @@
 package jaega.homecare.domain.caregiver.entity;
 
 import jaega.homecare.domain.center.dto.req.CreateCaregiverProfileRequest;
-import jaega.homecare.domain.users.entity.Location;
 import jaega.homecare.domain.users.entity.ServiceType;
 import jaega.homecare.domain.users.entity.User;
 import jaega.homecare.global.audit.BaseTimeEntity;
@@ -43,9 +42,6 @@ public class Caregiver extends BaseTimeEntity {
     @Column(name = "address")
     private String address;
 
-    @Embedded
-    private Location location;
-
     // 서비스 유형 (다중 선택 가능)
     @ElementCollection(targetClass = ServiceType.class, fetch = FetchType.LAZY)
     @CollectionTable(name = "service_type", joinColumns = @JoinColumn(name = "caregiver_id"))
@@ -60,16 +56,39 @@ public class Caregiver extends BaseTimeEntity {
     @Column(name = "day_of_week")
     private Set<DayOfWeek> dayOfWeek = new HashSet<>();
 
+    @Column(name = "career")
+    private Integer career;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "korean_proficiency")
+    private KoreanProficiency koreanProficiency;
+
+    @Column(name = "is_accompany_outing")
+    private boolean isAccompanyOuting;
+
+    @Column(name = "self_introduction", length = 1000)
+    private String selfIntroduction;
+
+    @Enumerated(EnumType.STRING)
+    private VerifiedStatus verifiedStatus;
+
     @Builder
-    public Caregiver(UUID caregiverId, User user, LocalTime availableStartTime, LocalTime availableEndTime, String address, Location location, Set<ServiceType> serviceTypes, Set<DayOfWeek> dayOfWeek) {
+    public Caregiver(UUID caregiverId, User user, LocalTime availableStartTime, LocalTime availableEndTime,
+                     String address, Set<ServiceType> serviceTypes, Set<DayOfWeek> dayOfWeek,
+                     Integer career, KoreanProficiency koreanProficiency, boolean isAccompanyOuting, String selfIntroduction,
+                     VerifiedStatus verifiedStatus) {
         this.caregiverId = caregiverId;
         this.user = user;
         this.availableStartTime = availableStartTime;
         this.availableEndTime = availableEndTime;
         this.address = address;
-        this.location = location;
         this.serviceTypes = serviceTypes;
         this.dayOfWeek = dayOfWeek;
+        this.career = career;
+        this.koreanProficiency = koreanProficiency;
+        this.isAccompanyOuting = isAccompanyOuting;
+        this.selfIntroduction = selfIntroduction;
+        this.verifiedStatus = VerifiedStatus.PENDING;
     }
 
     public void initializeCaregiver(UUID uuid) {
@@ -80,7 +99,6 @@ public class Caregiver extends BaseTimeEntity {
         this.availableStartTime = request.availableStartTIme();
         this.availableEndTime = request.availableEndTime();
         this.address = request.address();
-        this.location = request.location();
         this.serviceTypes = request.serviceTypes();
         this.dayOfWeek = request.dayOfWeek();
     }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
@@ -49,13 +49,6 @@ public class Caregiver extends BaseTimeEntity {
     @Column(name = "service_type")
     private Set<ServiceType> serviceTypes = new HashSet<>();
 
-    // 근무 가능 요일
-    @ElementCollection(targetClass = DayOfWeek.class, fetch = FetchType.LAZY)
-    @CollectionTable(name = "caregiver_day_of_week", joinColumns = @JoinColumn(name = "caregiver_id"))
-    @Enumerated(EnumType.STRING)
-    @Column(name = "day_of_week")
-    private Set<DayOfWeek> dayOfWeek = new HashSet<>();
-
     @Column(name = "career")
     private Integer career;
 
@@ -74,16 +67,14 @@ public class Caregiver extends BaseTimeEntity {
 
     @Builder
     public Caregiver(UUID caregiverId, User user, LocalTime availableStartTime, LocalTime availableEndTime,
-                     String address, Set<ServiceType> serviceTypes, Set<DayOfWeek> dayOfWeek,
-                     Integer career, KoreanProficiency koreanProficiency, boolean isAccompanyOuting, String selfIntroduction,
-                     VerifiedStatus verifiedStatus) {
+                     String address, Set<ServiceType> serviceTypes, Integer career,
+                     KoreanProficiency koreanProficiency, boolean isAccompanyOuting, String selfIntroduction, VerifiedStatus verifiedStatus) {
         this.caregiverId = caregiverId;
         this.user = user;
         this.availableStartTime = availableStartTime;
         this.availableEndTime = availableEndTime;
         this.address = address;
         this.serviceTypes = serviceTypes;
-        this.dayOfWeek = dayOfWeek;
         this.career = career;
         this.koreanProficiency = koreanProficiency;
         this.isAccompanyOuting = isAccompanyOuting;
@@ -93,13 +84,5 @@ public class Caregiver extends BaseTimeEntity {
 
     public void initializeCaregiver(UUID uuid) {
         this.caregiverId = uuid;
-    }
-
-    public void setCaregiverProfile(CreateCaregiverProfileRequest request){
-        this.availableStartTime = request.availableStartTIme();
-        this.availableEndTime = request.availableEndTime();
-        this.address = request.address();
-        this.serviceTypes = request.serviceTypes();
-        this.dayOfWeek = request.dayOfWeek();
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/KoreanProficiency.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/KoreanProficiency.java
@@ -1,0 +1,8 @@
+package jaega.homecare.domain.caregiver.entity;
+
+public enum KoreanProficiency {
+    BASIC,         // 기본 의사소통 가능
+    INTERMEDIATE,  // 일상 대화 가능
+    ADVANCED,      // 복잡한 대화 가능
+    NATIVE         // 원어민 수준
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/VerifiedStatus.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/VerifiedStatus.java
@@ -1,0 +1,7 @@
+package jaega.homecare.domain.caregiver.entity;
+
+public enum VerifiedStatus {
+    PENDING,  // 대기
+    APPROVED, // 승인
+    REJECTED  // 거절
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/mapper/CaregiverMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/mapper/CaregiverMapper.java
@@ -1,6 +1,8 @@
 package jaega.homecare.domain.caregiver.mapper;
 
 import jaega.homecare.domain.caregiver.dto.req.CaregiverCreateRequest;
+import jaega.homecare.domain.caregiver.dto.res.GetCaregiverSignupResponse;
+import jaega.homecare.domain.caregiver.dto.res.GetCaregiverVerifiedStatusResponse;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.center.dto.res.GetCaregiverProfileResponse;
 import jaega.homecare.domain.users.entity.User;
@@ -23,6 +25,13 @@ public interface CaregiverMapper {
     @Mapping(target = "serviceTypes", ignore = true)
     @Mapping(target = "dayOfWeek", ignore = true)
     Caregiver toEntity(CaregiverCreateRequest request, User user);
+
+    @Mapping(target = "caregiverId", source = "caregiverId")
+    GetCaregiverSignupResponse toGetCaregiverSignup(Caregiver caregiver);
+
+    @Mapping(target = "caregiverId", source = "caregiverId")
+    @Mapping(target = "verifiedStatus", source = "verifiedStatus")
+    GetCaregiverVerifiedStatusResponse toGetCaregiverVerifiedStatus(Caregiver caregiver);
 
     @Mapping(target = "caregiverName", source = "caregiver.user.name")
     @Mapping(target = "email", source = "caregiver.user.email")

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/mapper/CaregiverMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/mapper/CaregiverMapper.java
@@ -1,7 +1,7 @@
 package jaega.homecare.domain.caregiver.mapper;
 
+import jaega.homecare.domain.caregiver.dto.req.CaregiverCreateRequest;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
-import jaega.homecare.domain.center.dto.req.CreateCaregiverRequest;
 import jaega.homecare.domain.center.dto.res.GetCaregiverProfileResponse;
 import jaega.homecare.domain.users.entity.User;
 import org.mapstruct.Mapper;
@@ -10,25 +10,19 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring")
 public interface CaregiverMapper {
 
-    @Mapping(target = "name", source = "request.name")
-    @Mapping(target = "email", source = "request.email")
-    @Mapping(target = "password", source = "password")
-    @Mapping(target = "phone", source = "request.phone")
-    @Mapping(target = "birthDate", source = "request.birthDate")
-    @Mapping(target = "userId", ignore = true)
-    @Mapping(target = "userRole", ignore = true)
-    @Mapping(target = "createdAt", ignore = true)
-    User toUserEntity(CreateCaregiverRequest request, String password);
-
-    @Mapping(target = "address", source = "address")
     @Mapping(target = "user", source = "user")
+    @Mapping(target = "availableStartTime", source = "request.availableStartTime")
+    @Mapping(target = "availableEndTime", source = "request.availableEndTime")
+    @Mapping(target = "address", source = "request.address")
+    @Mapping(target = "career", source = "request.career")
+    @Mapping(target = "koreanProficiency", source = "request.koreanProficiency")
+    @Mapping(target = "isAccompanyOuting", source = "request.isAccompanyOuting")
+    @Mapping(target = "selfIntroduction", source = "request.selfIntroduction")
+    @Mapping(target = "verifiedStatus", source = "request.verifiedStatus")
     @Mapping(target = "caregiverId", ignore = true)
-    @Mapping(target = "availableStartTime", ignore = true)
-    @Mapping(target = "availableEndTime", ignore = true)
     @Mapping(target = "serviceTypes", ignore = true)
     @Mapping(target = "dayOfWeek", ignore = true)
-    @Mapping(target = "location", ignore = true)
-    Caregiver toEntity(String address, User user);
+    Caregiver toEntity(CaregiverCreateRequest request, User user);
 
     @Mapping(target = "caregiverName", source = "caregiver.user.name")
     @Mapping(target = "email", source = "caregiver.user.email")

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/mapper/CaregiverMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/mapper/CaregiverMapper.java
@@ -4,6 +4,7 @@ import jaega.homecare.domain.caregiver.dto.req.CaregiverCreateRequest;
 import jaega.homecare.domain.caregiver.dto.res.GetCaregiverSignupResponse;
 import jaega.homecare.domain.caregiver.dto.res.GetCaregiverVerifiedStatusResponse;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.domain.caregiverPreference.entity.CaregiverPreference;
 import jaega.homecare.domain.center.dto.res.GetCaregiverProfileResponse;
 import jaega.homecare.domain.users.entity.User;
 import org.mapstruct.Mapper;
@@ -22,7 +23,6 @@ public interface CaregiverMapper {
     @Mapping(target = "selfIntroduction", source = "request.selfIntroduction")
     @Mapping(target = "verifiedStatus", source = "request.verifiedStatus")
     @Mapping(target = "caregiverId", ignore = true)
-    @Mapping(target = "serviceTypes", ignore = true)
     Caregiver toEntity(CaregiverCreateRequest request, User user);
 
     @Mapping(target = "caregiverId", source = "caregiverId")
@@ -36,5 +36,6 @@ public interface CaregiverMapper {
     @Mapping(target = "email", source = "caregiver.user.email")
     @Mapping(target = "birthDate", source = "caregiver.user.birthDate")
     @Mapping(target = "phone", source = "caregiver.user.phone")
-    GetCaregiverProfileResponse toGetCaregiverProfile(Caregiver caregiver);
+    @Mapping(target = "serviceTypes", source = "preference.serviceTypes")
+    GetCaregiverProfileResponse toGetCaregiverProfile(Caregiver caregiver, CaregiverPreference preference);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/mapper/CaregiverMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/mapper/CaregiverMapper.java
@@ -23,7 +23,6 @@ public interface CaregiverMapper {
     @Mapping(target = "verifiedStatus", source = "request.verifiedStatus")
     @Mapping(target = "caregiverId", ignore = true)
     @Mapping(target = "serviceTypes", ignore = true)
-    @Mapping(target = "dayOfWeek", ignore = true)
     Caregiver toEntity(CaregiverCreateRequest request, User user);
 
     @Mapping(target = "caregiverId", source = "caregiverId")

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverQueryRepository.java
@@ -1,11 +1,14 @@
 package jaega.homecare.domain.caregiver.repository;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.caregiverCenter.entity.CaregiverCenter;
 import jaega.homecare.domain.caregiverCenter.entity.CaregiverStatus;
 import jaega.homecare.domain.caregiver.entity.QCaregiver;
+import jaega.homecare.domain.caregiverPreference.entity.CaregiverPreference;
+import jaega.homecare.domain.caregiverPreference.entity.QCaregiverPreference;
 import jaega.homecare.domain.center.entity.Center;
 import jaega.homecare.domain.caregiverCenter.entity.QCaregiverCenter;
 import jaega.homecare.domain.users.entity.ServiceType;
@@ -16,9 +19,7 @@ import jaega.homecare.domain.users.entity.QUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 @Repository
 @RequiredArgsConstructor
@@ -30,24 +31,34 @@ public class CaregiverQueryRepository {
         QCaregiver caregiver = QCaregiver.caregiver;
         QUser user = QUser.user;
         QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
+        QCaregiverPreference preference = QCaregiverPreference.caregiverPreference;
 
-        List<CaregiverCenter> caregiverCenters = queryFactory
-                .selectFrom(caregiverCenter).distinct()
+        // Caregiver + Preference fetch 조인
+        List<Tuple> results = queryFactory
+                .select(caregiverCenter, caregiver, preference)
+                .from(caregiverCenter)
                 .join(caregiverCenter.caregiver, caregiver).fetchJoin()
                 .join(caregiver.user, user).fetchJoin()
+                .leftJoin(preference).on(preference.caregiver.eq(caregiver))
                 .where(caregiverCenter.center.centerId.eq(centerId))
                 .fetch();
 
-        return caregiverCenters.stream()
-                .distinct()
-                .map(cc -> {
-                    Caregiver c = cc.getCaregiver();
+        return results.stream()
+                .map(tuple -> {
+                    Caregiver c = tuple.get(caregiver);
+                    CaregiverPreference pref = tuple.get(preference);
+
+                    // 선호 서비스 타입만 가져오기
+                    Set<ServiceType> serviceTypes = pref != null && pref.getServiceTypes() != null
+                            ? pref.getServiceTypes()
+                            : Collections.emptySet();
+
                     return new GetCaregiverResponse(
                             c.getCaregiverId(),
                             c.getUser().getName(),
                             c.getUser().getPhone(),
-                            c.getServiceTypes(),
-                            cc.getStatus()
+                            serviceTypes,
+                            tuple.get(caregiverCenter).getStatus()
                     );
                 })
                 .toList();
@@ -65,7 +76,6 @@ public class CaregiverQueryRepository {
                 .selectFrom(caregiverCenter).distinct()
                 .join(caregiverCenter.caregiver, caregiver).fetchJoin()
                 .join(caregiver.user, user).fetchJoin()
-                .leftJoin(caregiver.serviceTypes).fetchJoin()
                 .where(
                         caregiverCenter.center.centerId.eq(centerId)
                                 .and(caregiverCenter.status.eq(status))
@@ -87,22 +97,39 @@ public class CaregiverQueryRepository {
         QCaregiver caregiver = QCaregiver.caregiver;
         QUser user = QUser.user;
         QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
+        QCaregiverPreference preference = QCaregiverPreference.caregiverPreference;
 
-        List<CaregiverCenter> caregiverCenters = queryFactory
-                .selectFrom(caregiverCenter).distinct()
-                .join(caregiverCenter.caregiver, caregiver).fetchJoin()
-                .join(caregiver.user, user).fetchJoin()
-                .where(
-                        caregiverCenter.center.centerId.eq(centerId)
-                                .and(caregiver.serviceTypes.any().in(serviceTypes))
-                )
+        List<Tuple> results = queryFactory
+                .select(caregiver, preference)
+                .from(caregiverCenter)
+                .join(caregiverCenter.caregiver, caregiver)
+                .join(caregiver.user, user)
+                .leftJoin(preference).on(preference.caregiver.eq(caregiver))
+                .where(caregiverCenter.center.centerId.eq(centerId))
                 .fetch();
 
-        return caregiverCenters.stream()
-                .map(cc -> new GetCaregiverByServiceTypeResponse(
-                        cc.getCaregiver().getUser().getName(),
-                        cc.getCaregiver().getServiceTypes()
-                ))
+        return results.stream()
+                .filter(tuple -> {
+                    Caregiver c = tuple.get(caregiver);
+                    CaregiverPreference pref = tuple.get(preference);
+
+                    Set<ServiceType> combined = new HashSet<>();
+                    if (pref.getServiceTypes() != null) combined.addAll(pref.getServiceTypes());
+                    if (pref != null && pref.getServiceTypes() != null) combined.addAll(pref.getServiceTypes());
+
+                    return !Collections.disjoint(combined, serviceTypes);
+                })
+                .map(tuple -> {
+                    Caregiver c = tuple.get(caregiver);
+                    CaregiverPreference pref = tuple.get(preference);
+                    Set<ServiceType> combined = new HashSet<>(pref.getServiceTypes());
+                    if (tuple.get(preference) != null) combined.addAll(tuple.get(preference).getServiceTypes());
+
+                    return new GetCaregiverByServiceTypeResponse(
+                            c.getUser().getName(),
+                            combined
+                    );
+                })
                 .toList();
     }
 

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverQueryRepository.java
@@ -110,24 +110,19 @@ public class CaregiverQueryRepository {
 
         return results.stream()
                 .filter(tuple -> {
-                    Caregiver c = tuple.get(caregiver);
                     CaregiverPreference pref = tuple.get(preference);
+                    if (pref == null || pref.getServiceTypes() == null) return false;
 
-                    Set<ServiceType> combined = new HashSet<>();
-                    if (pref.getServiceTypes() != null) combined.addAll(pref.getServiceTypes());
-                    if (pref != null && pref.getServiceTypes() != null) combined.addAll(pref.getServiceTypes());
-
-                    return !Collections.disjoint(combined, serviceTypes);
+                    // Preference 서비스 타입과 요청한 serviceTypes 간 교집합 확인
+                    return !Collections.disjoint(pref.getServiceTypes(), serviceTypes);
                 })
                 .map(tuple -> {
                     Caregiver c = tuple.get(caregiver);
                     CaregiverPreference pref = tuple.get(preference);
-                    Set<ServiceType> combined = new HashSet<>(pref.getServiceTypes());
-                    if (tuple.get(preference) != null) combined.addAll(tuple.get(preference).getServiceTypes());
 
                     return new GetCaregiverByServiceTypeResponse(
                             c.getUser().getName(),
-                            combined
+                            pref.getServiceTypes()
                     );
                 })
                 .toList();

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverRepository.java
@@ -13,6 +13,10 @@ import java.util.UUID;
 public interface CaregiverRepository extends JpaRepository<Caregiver, Long>{
     Optional<Caregiver> findByCaregiverId(UUID caregiverId);
 
-    @Query("select c.caregiverId, st from Caregiver c join c.serviceTypes st where c.caregiverId in :caregiverIds")
+    @Query("select c.caregiverId, st " +
+            "from Caregiver c " +
+            "left join CaregiverPreference pref on pref.caregiver = c " +
+            "join pref.serviceTypes st " +
+            "where c.caregiverId in :caregiverIds")
     List<Object[]> findServiceTypesByCaregiverIds(@Param("caregiverIds") Set<UUID> caregiverIds);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/service/command/CaregiverCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/service/command/CaregiverCommandService.java
@@ -2,6 +2,7 @@ package jaega.homecare.domain.caregiver.service.command;
 
 import jaega.homecare.domain.caregiver.dto.req.CaregiverSignupRequest;
 import jaega.homecare.domain.caregiver.dto.req.CaregiverCreateRequest;
+import jaega.homecare.domain.caregiver.dto.res.GetCaregiverSignupResponse;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.caregiver.repository.CaregiverRepository;
 import jaega.homecare.domain.caregiver.mapper.CaregiverMapper;
@@ -24,10 +25,11 @@ public class CaregiverCommandService {
     private final CertificationCommandService certificationCommandService;
     private final UserCommandService userCommandService;
 
-    public void signupCaregiver(CaregiverSignupRequest request){
+    public GetCaregiverSignupResponse signupCaregiver(CaregiverSignupRequest request){
         User user = userCommandService.createUser(request.user(), UserRole.ROLE_CAREGIVER);
         Caregiver caregiver = createCaregiver(request.caregiver(), user);
         certificationCommandService.createCertification(request.certification(), caregiver);
+        return caregiverMapper.toGetCaregiverSignup(caregiver);
     }
 
     public Caregiver createCaregiver(CaregiverCreateRequest request, User user) {

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/service/command/CaregiverCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/service/command/CaregiverCommandService.java
@@ -1,17 +1,13 @@
 package jaega.homecare.domain.caregiver.service.command;
 
+import jaega.homecare.domain.caregiver.dto.req.CaregiverSignupRequest;
+import jaega.homecare.domain.caregiver.dto.req.CaregiverCreateRequest;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
-import jaega.homecare.domain.caregiver.entity.Certification;
 import jaega.homecare.domain.caregiver.repository.CaregiverRepository;
-import jaega.homecare.domain.caregiver.repository.CertificationRepository;
-import jaega.homecare.domain.caregiver.service.query.CaregiverQueryService;
-import jaega.homecare.domain.caregiverCenter.service.command.CaregiverCenterCommandService;
-import jaega.homecare.domain.center.dto.req.CreateCaregiverProfileRequest;
-import jaega.homecare.domain.center.dto.req.CreateCaregiverRequest;
 import jaega.homecare.domain.caregiver.mapper.CaregiverMapper;
-import jaega.homecare.domain.center.entity.Center;
-import jaega.homecare.domain.center.service.query.CenterQueryService;
 import jaega.homecare.domain.users.entity.User;
+import jaega.homecare.domain.users.entity.UserRole;
+import jaega.homecare.domain.users.service.command.UserCommandService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,39 +21,20 @@ public class CaregiverCommandService {
 
     private final CaregiverMapper caregiverMapper;
     private final CaregiverRepository caregiverRepository;
-    private final CaregiverQueryService caregiverQueryService;
-    private final CertificationRepository certificationRepository;
-    private final CenterQueryService centerQueryService;
-    private final CaregiverCenterCommandService caregiverCenterCommandService;
+    private final CertificationCommandService certificationCommandService;
+    private final UserCommandService userCommandService;
 
-    // TODO: 기존 : 센터에서 요양보호사 생성, 변경 필요 : 요양보호사가 직접 회원가입 후 센터 선택
-    // TODO: 자격증 데이터만 생성하고 후에, 변경하는 것으로 되어있으나 자격증도 같이 등록하면 될듯 합니다!
-    public Caregiver createCaregiver(CreateCaregiverRequest createCaregiverRequest, User user, UUID centerId) {
-        String address = createCaregiverRequest.address();
-        Center center = centerQueryService.findCenterByUUID(centerId);
-        Caregiver caregiver = caregiverMapper.toEntity(address, user);
-        caregiver.initializeCaregiver(UUID.randomUUID());
-
-        // 자격증 기본 정보 없이 생성
-        Certification certification = Certification.builder()
-                .certificationId(UUID.randomUUID())
-                .caregiver(caregiver)
-                .certificationNumber(null)
-                .certificationDate(null)
-                .trainStatus(false)
-                .build();
-
-        certificationRepository.save(certification);
-        caregiverCenterCommandService.createCaregiverCenter(center, caregiver);
-
-        return caregiverRepository.save(caregiver);
+    public void signupCaregiver(CaregiverSignupRequest request){
+        User user = userCommandService.createUser(request.user(), UserRole.ROLE_CAREGIVER);
+        Caregiver caregiver = createCaregiver(request.caregiver(), user);
+        certificationCommandService.createCertification(request.certification(), caregiver);
     }
 
-    public void createCaregiverProfile(CreateCaregiverProfileRequest request){
-        Caregiver caregiver = caregiverQueryService.getCaregiver(request.caregiverId());
-        caregiver.setCaregiverProfile(request);
+    public Caregiver createCaregiver(CaregiverCreateRequest request, User user) {
+        Caregiver caregiver = caregiverMapper.toEntity(request, user);
+        caregiver.initializeCaregiver(UUID.randomUUID());
 
-        caregiverRepository.save(caregiver);
+        return caregiverRepository.save(caregiver);
     }
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/service/command/CertificationCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/service/command/CertificationCommandService.java
@@ -5,7 +5,6 @@ import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.caregiver.entity.Certification;
 import jaega.homecare.domain.caregiver.mapper.CertificationMapper;
 import jaega.homecare.domain.caregiver.repository.CertificationRepository;
-import jaega.homecare.domain.caregiver.service.query.CaregiverQueryService;
 import jaega.homecare.domain.caregiver.service.query.CertificationQueryService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -21,11 +20,9 @@ public class CertificationCommandService {
 
     private final CertificationRepository certificationRepository;
     private final CertificationMapper certificationMapper;
-    private final CaregiverQueryService caregiverQueryService;
     private final CertificationQueryService certificationQueryService;
 
-    public void createCertification(CreateCertificationRequest request) {
-        Caregiver caregiver = caregiverQueryService.getCaregiver(request.caregiverId());
+    public void createCertification(CreateCertificationRequest request, Caregiver caregiver) {
 
         // 자격증이 이미 있는지 확인 (caregiver 기준으로 조회한다고 가정)
         Optional<Certification> optionalCertification = certificationRepository.findByCaregiver(caregiver);

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/service/query/CaregiverQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/service/query/CaregiverQueryService.java
@@ -1,5 +1,6 @@
 package jaega.homecare.domain.caregiver.service.query;
 
+import jaega.homecare.domain.caregiver.dto.res.GetCaregiverVerifiedStatusResponse;
 import jaega.homecare.domain.caregiver.dto.res.GetDashboardPopularResponse;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.caregiverCenter.entity.CaregiverStatus;
@@ -30,13 +31,20 @@ public class CaregiverQueryService {
     private final CaregiverRepository caregiverRepository;
     private final CaregiverMapper caregiverMapper;
 
-    public List<GetCaregiverResponse> getAllCaregiversByCenter(UUID centerId) {
-        return caregiverQueryRepository.findAllByCenterId(centerId);
-    }
-
     public Caregiver getCaregiver(UUID caregiverId){
         return caregiverRepository.findByCaregiverId(caregiverId)
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 요양보호사입니다."));
+    }
+
+    public GetCaregiverVerifiedStatusResponse getCaregiverVerifiedStatus(UUID caregiverId){
+        Caregiver caregiver = getCaregiver(caregiverId);
+        return caregiverMapper.toGetCaregiverVerifiedStatus(caregiver);
+    }
+
+    // 센터(웹 페이지) 조회
+
+    public List<GetCaregiverResponse> getAllCaregiversByCenter(UUID centerId) {
+        return caregiverQueryRepository.findAllByCenterId(centerId);
     }
 
     public List<GetCaregiverByCaregiverStatusResponse> getCaregiverByWorkStatus(UUID centerId, CaregiverStatus status){

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/service/query/CaregiverQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/service/query/CaregiverQueryService.java
@@ -7,6 +7,9 @@ import jaega.homecare.domain.caregiverCenter.entity.CaregiverStatus;
 import jaega.homecare.domain.caregiver.mapper.CaregiverMapper;
 import jaega.homecare.domain.caregiver.repository.CaregiverQueryRepository;
 import jaega.homecare.domain.caregiver.repository.CaregiverRepository;
+import jaega.homecare.domain.caregiverPreference.dto.res.GetCaregiverPreferenceResponse;
+import jaega.homecare.domain.caregiverPreference.entity.CaregiverPreference;
+import jaega.homecare.domain.caregiverPreference.service.query.CaregiverPreferenceQueryService;
 import jaega.homecare.domain.center.dto.res.GetCaregiverByCaregiverStatusResponse;
 import jaega.homecare.domain.center.dto.res.GetCaregiverByServiceTypeResponse;
 import jaega.homecare.domain.center.dto.res.GetCaregiverProfileResponse;
@@ -27,6 +30,7 @@ import java.util.UUID;
 public class CaregiverQueryService {
 
     private final CenterQueryService centerQueryService;
+    private final CaregiverPreferenceQueryService caregiverPreferenceQueryService;
     private final CaregiverQueryRepository caregiverQueryRepository;
     private final CaregiverRepository caregiverRepository;
     private final CaregiverMapper caregiverMapper;
@@ -57,7 +61,8 @@ public class CaregiverQueryService {
 
     public GetCaregiverProfileResponse getCaregiverProfile(UUID caregiverId){
         Caregiver caregiver = getCaregiver(caregiverId);
-        return caregiverMapper.toGetCaregiverProfile(caregiver);
+        CaregiverPreference caregiverPreference = caregiverPreferenceQueryService.findCaregiverPreferenceByCaregiver(caregiverId);
+        return caregiverMapper.toGetCaregiverProfile(caregiver, caregiverPreference);
     }
 
 

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/controller/CaregiverPreferenceController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/controller/CaregiverPreferenceController.java
@@ -4,11 +4,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jaega.homecare.domain.caregiverPreference.dto.req.CreateCaregiverPreferenceRequest;
+import jaega.homecare.domain.caregiverPreference.dto.res.GetCaregiverPreferenceResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
@@ -18,8 +16,13 @@ public interface CaregiverPreferenceController {
 
     @Operation(summary = "요양보호사 선호(근무) 조건 작성 API", description = "입력받은 정보로 요양보호사의 선호(근무) 조건을 생성합니다.")
     @ApiResponse(responseCode = "204", description = "요양보호사의 선호(근무) 조건 생성 성공")
-    @PostMapping("/{caregiverId}")
+    @PostMapping
     ResponseEntity<Void> createCaregiverPreference(
-            @PathVariable UUID caregiverId,
+            @RequestParam UUID caregiverId,
             @RequestBody CreateCaregiverPreferenceRequest request);
+
+    @Operation(summary = "요양보호사의 선호(근무) 조건 조회 API", description = "요양보호사가 자신의 선호(근무) 조건을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "요양보호사의 선호(근무)조건 조회 성공")
+    @GetMapping
+    ResponseEntity<GetCaregiverPreferenceResponse> getCaregiverPreferenceByCaregiver(@RequestParam UUID caregiverId);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/controller/CaregiverPreferenceController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/controller/CaregiverPreferenceController.java
@@ -1,0 +1,25 @@
+package jaega.homecare.domain.caregiverPreference.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jaega.homecare.domain.caregiverPreference.dto.req.CreateCaregiverPreferenceRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.UUID;
+
+@Tag(name = "CaregiverPreference", description = "요양보호사의 선호(근무) 조건 API")
+@RequestMapping("/api/caregiver/preference")
+public interface CaregiverPreferenceController {
+
+    @Operation(summary = "요양보호사 선호(근무) 조건 작성 API", description = "입력받은 정보로 요양보호사의 선호(근무) 조건을 생성합니다.")
+    @ApiResponse(responseCode = "204", description = "요양보호사의 선호(근무) 조건 생성 성공")
+    @PostMapping("/{caregiverId}")
+    ResponseEntity<Void> createCaregiverPreference(
+            @PathVariable UUID caregiverId,
+            @RequestBody CreateCaregiverPreferenceRequest request);
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/controller/CaregiverPreferenceControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/controller/CaregiverPreferenceControllerImpl.java
@@ -1,14 +1,12 @@
 package jaega.homecare.domain.caregiverPreference.controller;
 
 import jaega.homecare.domain.caregiverPreference.dto.req.CreateCaregiverPreferenceRequest;
+import jaega.homecare.domain.caregiverPreference.dto.res.GetCaregiverPreferenceResponse;
 import jaega.homecare.domain.caregiverPreference.service.command.CaregiverPreferenceCommandService;
 import jaega.homecare.domain.caregiverPreference.service.query.CaregiverPreferenceQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
@@ -22,10 +20,16 @@ public class CaregiverPreferenceControllerImpl implements CaregiverPreferenceCon
 
     @Override
     public ResponseEntity<Void> createCaregiverPreference(
-            @PathVariable UUID caregiverId,
+            @RequestParam UUID caregiverId,
             @RequestBody CreateCaregiverPreferenceRequest request){
         caregiverPreferenceCommandService.createCaregiverPreference(request, caregiverId);
         return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<GetCaregiverPreferenceResponse> getCaregiverPreferenceByCaregiver(@RequestParam UUID caregiverId){
+        GetCaregiverPreferenceResponse response = caregiverPreferenceQueryService.getCaregiverPreferenceByCaregiver(caregiverId);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/controller/CaregiverPreferenceControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/controller/CaregiverPreferenceControllerImpl.java
@@ -1,0 +1,31 @@
+package jaega.homecare.domain.caregiverPreference.controller;
+
+import jaega.homecare.domain.caregiverPreference.dto.req.CreateCaregiverPreferenceRequest;
+import jaega.homecare.domain.caregiverPreference.service.command.CaregiverPreferenceCommandService;
+import jaega.homecare.domain.caregiverPreference.service.query.CaregiverPreferenceQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/caregiver/preference")
+public class CaregiverPreferenceControllerImpl implements CaregiverPreferenceController{
+
+    private final CaregiverPreferenceCommandService caregiverPreferenceCommandService;
+    private final CaregiverPreferenceQueryService caregiverPreferenceQueryService;
+
+    @Override
+    public ResponseEntity<Void> createCaregiverPreference(
+            @PathVariable UUID caregiverId,
+            @RequestBody CreateCaregiverPreferenceRequest request){
+        caregiverPreferenceCommandService.createCaregiverPreference(request, caregiverId);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/dto/req/CreateCaregiverPreferenceRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/dto/req/CreateCaregiverPreferenceRequest.java
@@ -1,0 +1,48 @@
+package jaega.homecare.domain.caregiverPreference.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jaega.homecare.domain.caregiverPreference.entity.PreferredGender;
+import jaega.homecare.domain.users.entity.Disease;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.Set;
+
+public record CreateCaregiverPreferenceRequest(
+        Set<DayOfWeek> dayOfWeek,
+
+        @Schema(type = "string", format = "time", example = "09:00:00")
+        LocalTime workStartTime,
+
+        @Schema(type = "string", format = "time", example = "18:00:00")
+        LocalTime workEndTime,
+
+        @Schema(type = "integer", example = "3600")
+        Integer workMinTime,
+
+        @Schema(type = "integer", example = "10800")
+        Integer workMaxTime,
+
+        @Schema(type = "integer", example = "1800")
+        Integer availableTime,
+
+        String workArea,
+        String transportation,
+
+        @Schema(type = "integer", example = "3600")
+        Integer lunchBreak,
+
+        @Schema(type = "integer", example = "1800")
+        Integer bufferTime,
+
+        Set<Disease> supportedConditions,
+
+        @Schema(type = "integer", example = "60")
+        Integer preferredMinAge,
+
+        @Schema(type = "integer", example = "90")
+        Integer preferredMaxAge,
+
+        PreferredGender preferredGender
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/dto/req/CreateCaregiverPreferenceRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/dto/req/CreateCaregiverPreferenceRequest.java
@@ -3,6 +3,7 @@ package jaega.homecare.domain.caregiverPreference.dto.req;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jaega.homecare.domain.caregiverPreference.entity.PreferredGender;
 import jaega.homecare.domain.users.entity.Disease;
+import jaega.homecare.domain.users.entity.ServiceType;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;
@@ -43,6 +44,7 @@ public record CreateCaregiverPreferenceRequest(
         @Schema(type = "integer", example = "90")
         Integer preferredMaxAge,
 
-        PreferredGender preferredGender
+        PreferredGender preferredGender,
+        Set<ServiceType> serviceTypes
 ) {
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/dto/res/GetCaregiverPreferenceResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/dto/res/GetCaregiverPreferenceResponse.java
@@ -1,0 +1,49 @@
+package jaega.homecare.domain.caregiverPreference.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jaega.homecare.domain.caregiverPreference.entity.PreferredGender;
+import jaega.homecare.domain.users.entity.Disease;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.Set;
+import java.util.UUID;
+
+public record GetCaregiverPreferenceResponse(
+        UUID caregiverPreferenceId,
+        Set<DayOfWeek> dayOfWeek,
+        @Schema(type = "string", format = "time", example = "09:00:00")
+        LocalTime workStartTime,
+
+        @Schema(type = "string", format = "time", example = "18:00:00")
+        LocalTime workEndTime,
+
+        @Schema(type = "integer", example = "3600")
+        Integer workMinTime,
+
+        @Schema(type = "integer", example = "10800")
+        Integer workMaxTime,
+
+        @Schema(type = "integer", example = "1800")
+        Integer availableTime,
+
+        String workArea,
+        String transportation,
+
+        @Schema(type = "integer", example = "3600")
+        Integer lunchBreak,
+
+        @Schema(type = "integer", example = "1800")
+        Integer bufferTime,
+
+        Set<Disease> supportedConditions,
+
+        @Schema(type = "integer", example = "60")
+        Integer preferredMinAge,
+
+        @Schema(type = "integer", example = "90")
+        Integer preferredMaxAge,
+
+        PreferredGender preferredGender
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/dto/res/GetCaregiverPreferenceResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/dto/res/GetCaregiverPreferenceResponse.java
@@ -3,6 +3,7 @@ package jaega.homecare.domain.caregiverPreference.dto.res;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jaega.homecare.domain.caregiverPreference.entity.PreferredGender;
 import jaega.homecare.domain.users.entity.Disease;
+import jaega.homecare.domain.users.entity.ServiceType;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;
@@ -44,6 +45,7 @@ public record GetCaregiverPreferenceResponse(
         @Schema(type = "integer", example = "90")
         Integer preferredMaxAge,
 
-        PreferredGender preferredGender
+        PreferredGender preferredGender,
+        Set<ServiceType> serviceTypes
 ) {
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/entity/CaregiverPreference.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/entity/CaregiverPreference.java
@@ -1,0 +1,113 @@
+package jaega.homecare.domain.caregiverPreference.entity;
+
+import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.domain.users.entity.Disease;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "caregiverPreference")
+@NoArgsConstructor
+public class CaregiverPreference {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(name = "caregiver_preference_id", unique = true)
+    private UUID caregiverPreferenceId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "caregiver_id")
+    private Caregiver caregiver;
+
+    // 근무 가능 요일
+    @ElementCollection(targetClass = DayOfWeek.class, fetch = FetchType.LAZY)
+    @CollectionTable(name = "caregiver_day_of_week", joinColumns = @JoinColumn(name = "caregiver_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "day_of_week")
+    private Set<DayOfWeek> dayOfWeek = new HashSet<>();
+
+    @Column(name = "work_start_time")
+    private LocalTime workStartTime;
+
+    @Column(name = "work_end_time")
+    private LocalTime workEndTime;
+
+    @Column(name = "work_min_time")
+    private Integer workMinTime;
+
+    @Column(name = "work_max_time")
+    private Integer workMaxTime;
+
+    @Column(name = "available_time")
+    private Integer availableTime;
+
+    @Column(name = "work_area")
+    private String workArea;
+
+    @Column(name = "transportation")
+    private String transportation;
+
+    @Column(name = "lunch_break")
+    private Integer lunchBreak;
+
+    @Column(name = "buffer_time")
+    private Integer bufferTime;
+
+    // 지원 가능 질환
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "caregiver_supported_conditions", joinColumns = @JoinColumn(name = "caregiver_preference_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "disease")
+    private Set<Disease> supportedConditions = new HashSet<>();
+
+    // 선호 연령
+    @Column(name = "preferred_min_age")
+    private Integer preferredMinAge;
+
+    @Column(name = "preferred_max_age")
+    private Integer preferredMaxAge;
+
+    // 선호 성별
+    @Enumerated(EnumType.STRING)
+    @Column(name = "preferred_gender")
+    private PreferredGender preferredGender;
+
+    @Builder
+    public CaregiverPreference(UUID caregiverPreferenceId, Caregiver caregiver, Set<DayOfWeek> dayOfWeek,
+                               LocalTime workStartTime, LocalTime workEndTime, Integer workMinTime, Integer workMaxTime,
+                               Integer availableTime, String workArea, String transportation, Integer lunchBreak, Integer bufferTime,
+                               Set<Disease> supportedConditions, Integer preferredMaxAge, Integer preferredMinAge, PreferredGender preferredGender){
+        this.caregiverPreferenceId = caregiverPreferenceId;
+        this.caregiver = caregiver;
+        this.dayOfWeek = dayOfWeek;
+        this.workStartTime = workStartTime;
+        this.workEndTime = workEndTime;
+        this.workMinTime = workMinTime;
+        this.workMaxTime = workMaxTime;
+        this.availableTime = availableTime;
+        this.workArea = workArea;
+        this.transportation = transportation;
+        this.lunchBreak = lunchBreak;
+        this.bufferTime = bufferTime;
+        this.supportedConditions = supportedConditions;
+        this.preferredMinAge = preferredMinAge;
+        this.preferredMaxAge = preferredMaxAge;
+        this.preferredGender = preferredGender;
+    }
+
+    public void initializeCaregiverPreference(UUID caregiverPreferenceId){
+        this.caregiverPreferenceId = caregiverPreferenceId;
+    }
+
+
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/entity/CaregiverPreference.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/entity/CaregiverPreference.java
@@ -2,6 +2,7 @@ package jaega.homecare.domain.caregiverPreference.entity;
 
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.users.entity.Disease;
+import jaega.homecare.domain.users.entity.ServiceType;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -67,7 +68,7 @@ public class CaregiverPreference {
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "caregiver_supported_conditions", joinColumns = @JoinColumn(name = "caregiver_preference_id"))
     @Enumerated(EnumType.STRING)
-    @Column(name = "disease")
+    @Column(name = "supported_conditions")
     private Set<Disease> supportedConditions = new HashSet<>();
 
     // 선호 연령
@@ -82,11 +83,19 @@ public class CaregiverPreference {
     @Column(name = "preferred_gender")
     private PreferredGender preferredGender;
 
+    // 서비스 유형 (다중 선택 가능)
+    @ElementCollection(targetClass = ServiceType.class, fetch = FetchType.LAZY)
+    @CollectionTable(name = "service_type", joinColumns = @JoinColumn(name = "caregiver_preference_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "caregiver_service_type")
+    private Set<ServiceType> serviceTypes = new HashSet<>();
+
     @Builder
     public CaregiverPreference(UUID caregiverPreferenceId, Caregiver caregiver, Set<DayOfWeek> dayOfWeek,
                                LocalTime workStartTime, LocalTime workEndTime, Integer workMinTime, Integer workMaxTime,
                                Integer availableTime, String workArea, String transportation, Integer lunchBreak, Integer bufferTime,
-                               Set<Disease> supportedConditions, Integer preferredMaxAge, Integer preferredMinAge, PreferredGender preferredGender){
+                               Set<Disease> supportedConditions, Integer preferredMaxAge, Integer preferredMinAge, PreferredGender preferredGender,
+                               Set<ServiceType> serviceTypes){
         this.caregiverPreferenceId = caregiverPreferenceId;
         this.caregiver = caregiver;
         this.dayOfWeek = dayOfWeek;
@@ -103,6 +112,7 @@ public class CaregiverPreference {
         this.preferredMinAge = preferredMinAge;
         this.preferredMaxAge = preferredMaxAge;
         this.preferredGender = preferredGender;
+        this.serviceTypes = serviceTypes;
     }
 
     public void initializeCaregiverPreference(UUID caregiverPreferenceId){

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/entity/PreferredGender.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/entity/PreferredGender.java
@@ -3,5 +3,5 @@ package jaega.homecare.domain.caregiverPreference.entity;
 public enum PreferredGender {
     ALL,
     MALE,
-    GENDER
+    FEMALE
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/entity/PreferredGender.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/entity/PreferredGender.java
@@ -1,0 +1,7 @@
+package jaega.homecare.domain.caregiverPreference.entity;
+
+public enum PreferredGender {
+    ALL,
+    MALE,
+    GENDER
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/mapper/CaregiverPreferenceMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/mapper/CaregiverPreferenceMapper.java
@@ -1,0 +1,29 @@
+package jaega.homecare.domain.caregiverPreference.mapper;
+
+import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.domain.caregiverPreference.dto.req.CreateCaregiverPreferenceRequest;
+import jaega.homecare.domain.caregiverPreference.entity.CaregiverPreference;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface CaregiverPreferenceMapper {
+
+    @Mapping(target = "caregiver", source = "caregiver")
+    @Mapping(target = "dayOfWeek", source = "request.dayOfWeek")
+    @Mapping(target = "workStartTime", source = "request.workStartTime")
+    @Mapping(target = "workEndTime", source = "request.workEndTime")
+    @Mapping(target = "workMinTime", source = "request.workMinTime")
+    @Mapping(target = "workMaxTime", source = "request.workMaxTime")
+    @Mapping(target = "availableTime", source = "request.availableTime")
+    @Mapping(target = "workArea", source = "request.workArea")
+    @Mapping(target = "transportation", source = "request.transportation")
+    @Mapping(target = "lunchBreak", source = "request.lunchBreak")
+    @Mapping(target = "bufferTime", source = "request.bufferTime")
+    @Mapping(target = "supportedConditions", source = "request.supportedConditions")
+    @Mapping(target = "preferredMinAge", source = "request.preferredMinAge")
+    @Mapping(target = "preferredMaxAge", source = "request.preferredMaxAge")
+    @Mapping(target = "preferredGender", source = "request.preferredGender")
+    @Mapping(target = "caregiverPreferenceId", ignore = true)
+    CaregiverPreference toEntity(CreateCaregiverPreferenceRequest request, Caregiver caregiver);
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/mapper/CaregiverPreferenceMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/mapper/CaregiverPreferenceMapper.java
@@ -25,6 +25,7 @@ public interface CaregiverPreferenceMapper {
     @Mapping(target = "preferredMinAge", source = "request.preferredMinAge")
     @Mapping(target = "preferredMaxAge", source = "request.preferredMaxAge")
     @Mapping(target = "preferredGender", source = "request.preferredGender")
+    @Mapping(target = "serviceTypes", source = "request.serviceTypes")
     @Mapping(target = "caregiverPreferenceId", ignore = true)
     CaregiverPreference toEntity(CreateCaregiverPreferenceRequest request, Caregiver caregiver);
 

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/mapper/CaregiverPreferenceMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/mapper/CaregiverPreferenceMapper.java
@@ -2,6 +2,7 @@ package jaega.homecare.domain.caregiverPreference.mapper;
 
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.caregiverPreference.dto.req.CreateCaregiverPreferenceRequest;
+import jaega.homecare.domain.caregiverPreference.dto.res.GetCaregiverPreferenceResponse;
 import jaega.homecare.domain.caregiverPreference.entity.CaregiverPreference;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -26,4 +27,6 @@ public interface CaregiverPreferenceMapper {
     @Mapping(target = "preferredGender", source = "request.preferredGender")
     @Mapping(target = "caregiverPreferenceId", ignore = true)
     CaregiverPreference toEntity(CreateCaregiverPreferenceRequest request, Caregiver caregiver);
+
+    GetCaregiverPreferenceResponse toGetResponse(CaregiverPreference caregiverPreference);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/repository/CaregiverPreferenceRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/repository/CaregiverPreferenceRepository.java
@@ -1,0 +1,9 @@
+package jaega.homecare.domain.caregiverPreference.repository;
+
+import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.domain.caregiverPreference.entity.CaregiverPreference;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CaregiverPreferenceRepository extends JpaRepository<CaregiverPreference, Long> {
+    CaregiverPreference findByCaregiver(Caregiver caregiver);
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/repository/CaregiverPreferenceRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/repository/CaregiverPreferenceRepository.java
@@ -1,9 +1,11 @@
 package jaega.homecare.domain.caregiverPreference.repository;
 
-import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.caregiverPreference.entity.CaregiverPreference;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 public interface CaregiverPreferenceRepository extends JpaRepository<CaregiverPreference, Long> {
-    CaregiverPreference findByCaregiver(Caregiver caregiver);
+    Optional<CaregiverPreference> findByCaregiver_CaregiverId(UUID caregiverId);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/service/command/CaregiverPreferenceCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/service/command/CaregiverPreferenceCommandService.java
@@ -1,0 +1,27 @@
+package jaega.homecare.domain.caregiverPreference.service.command;
+
+import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.domain.caregiver.service.query.CaregiverQueryService;
+import jaega.homecare.domain.caregiverPreference.dto.req.CreateCaregiverPreferenceRequest;
+import jaega.homecare.domain.caregiverPreference.entity.CaregiverPreference;
+import jaega.homecare.domain.caregiverPreference.mapper.CaregiverPreferenceMapper;
+import jaega.homecare.domain.caregiverPreference.repository.CaregiverPreferenceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CaregiverPreferenceCommandService {
+    private final CaregiverPreferenceRepository caregiverPreferenceRepository;
+    private final CaregiverPreferenceMapper caregiverPreferenceMapper;
+    private final CaregiverQueryService caregiverQueryService;
+
+    public void createCaregiverPreference(CreateCaregiverPreferenceRequest request, UUID caregiverId){
+        Caregiver caregiver = caregiverQueryService.getCaregiver(caregiverId);
+        CaregiverPreference caregiverPreference = caregiverPreferenceMapper.toEntity(request, caregiver);
+        caregiverPreference.initializeCaregiverPreference(UUID.randomUUID());
+        caregiverPreferenceRepository.save(caregiverPreference);
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/service/query/CaregiverPreferenceQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/service/query/CaregiverPreferenceQueryService.java
@@ -1,11 +1,28 @@
 package jaega.homecare.domain.caregiverPreference.service.query;
 
+import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.domain.caregiver.service.query.CaregiverQueryService;
+import jaega.homecare.domain.caregiverPreference.dto.res.GetCaregiverPreferenceResponse;
+import jaega.homecare.domain.caregiverPreference.entity.CaregiverPreference;
+import jaega.homecare.domain.caregiverPreference.mapper.CaregiverPreferenceMapper;
+import jaega.homecare.domain.caregiverPreference.repository.CaregiverPreferenceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class CaregiverPreferenceQueryService {
+    private final CaregiverPreferenceRepository caregiverPreferenceRepository;
+    private final CaregiverPreferenceMapper caregiverPreferenceMapper;
+    private final CaregiverQueryService caregiverQueryService;
+
+    public GetCaregiverPreferenceResponse getCaregiverPreferenceByCaregiver(UUID caregiverId){
+        Caregiver caregiver = caregiverQueryService.getCaregiver(caregiverId);
+        CaregiverPreference caregiverPreference = caregiverPreferenceRepository.findByCaregiver(caregiver);
+        return caregiverPreferenceMapper.toGetResponse(caregiverPreference);
+    }
 
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/service/query/CaregiverPreferenceQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/service/query/CaregiverPreferenceQueryService.java
@@ -6,6 +6,7 @@ import jaega.homecare.domain.caregiverPreference.dto.res.GetCaregiverPreferenceR
 import jaega.homecare.domain.caregiverPreference.entity.CaregiverPreference;
 import jaega.homecare.domain.caregiverPreference.mapper.CaregiverPreferenceMapper;
 import jaega.homecare.domain.caregiverPreference.repository.CaregiverPreferenceRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,11 +17,16 @@ import java.util.UUID;
 public class CaregiverPreferenceQueryService {
     private final CaregiverPreferenceRepository caregiverPreferenceRepository;
     private final CaregiverPreferenceMapper caregiverPreferenceMapper;
-    private final CaregiverQueryService caregiverQueryService;
 
+    // 도메인 조회 용
+    public CaregiverPreference findCaregiverPreferenceByCaregiver(UUID caregiverId){
+        return caregiverPreferenceRepository.findByCaregiver_CaregiverId(caregiverId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 요양보호사의 선호 조건을 찾을 수 없습니다."));
+    }
+
+    // 요양보호사 선호 조건 조회 API
     public GetCaregiverPreferenceResponse getCaregiverPreferenceByCaregiver(UUID caregiverId){
-        Caregiver caregiver = caregiverQueryService.getCaregiver(caregiverId);
-        CaregiverPreference caregiverPreference = caregiverPreferenceRepository.findByCaregiver(caregiver);
+        CaregiverPreference caregiverPreference = findCaregiverPreferenceByCaregiver(caregiverId);
         return caregiverPreferenceMapper.toGetResponse(caregiverPreference);
     }
 

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/service/query/CaregiverPreferenceQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverPreference/service/query/CaregiverPreferenceQueryService.java
@@ -1,0 +1,11 @@
+package jaega.homecare.domain.caregiverPreference.service.query;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CaregiverPreferenceQueryService {
+
+
+}

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
@@ -8,7 +8,6 @@ import jaega.homecare.domain.center.dto.res.GetCaregiverMatchesResponse;
 import jaega.homecare.domain.serviceMatch.dto.res.GetServiceMatchByCenterResponse;
 import jaega.homecare.domain.settlement.dto.res.GetDashboardSettlementResponse;
 import jaega.homecare.domain.settlement.dto.res.GetDashboardWorkStatusResponse;
-import jaega.homecare.domain.caregiver.dto.req.CreateCertificationRequest;
 import jaega.homecare.domain.caregiver.dto.res.GetCertificationResponse;
 import jaega.homecare.domain.caregiver.dto.res.GetDashboardPopularResponse;
 import jaega.homecare.domain.caregiverCenter.entity.CaregiverStatus;
@@ -32,21 +31,19 @@ public interface CenterController {
     @PostMapping("/login")
     ResponseEntity<CenterLoginResponse> loginCenter(@RequestBody CenterLoginRequest request);
 
+    /*
     @Operation(summary = "보호사 등록 API", description = "입력받은 정보로 새로운 요양 보호사를 등록합니다." +
             "요양 보호사 계정은 최초 등록 시 자동으로 생성됩니다.")
     @ApiResponse(responseCode = "204", description = "요양 보호사 등록 성공")
     @PostMapping("/{centerId}/caregiver")
-    ResponseEntity<Void> registerCaregiver(@RequestBody CreateCaregiverRequest createCaregiverRequest, @PathVariable UUID centerId);
+    ResponseEntity<Void> registerCaregiver(@RequestBody CreateCaregiverRequest7 createCaregiverRequest7, @PathVariable UUID centerId);
+
+     */
 
     @Operation(summary = "요양 보호사 말소 API", description = "입력받은 센터 ID와 보호사 ID를 이용하여 해당 요양 보호사를 말소(삭제)합니다.")
     @ApiResponse(responseCode = "204", description = "요양 보호사 말소 성공")
     @DeleteMapping("/{centerId}/caregiver/{caregiverId}")
     ResponseEntity<Void> deregisterCaregiver(@PathVariable UUID centerId, @PathVariable UUID caregiverId);
-
-    @Operation(summary = "보호사 상세 정보 등록 API", description = "입력받은 정보로 요양보호사의 프로필을 등록합니다.")
-    @ApiResponse(responseCode = "204", description = "요양 보호사 상세 정보 등록 성공")
-    @PostMapping("/caregiver")
-    ResponseEntity<Void> createCaregiverProfile(@RequestBody CreateCaregiverProfileRequest request);
 
     @Operation(summary = "보호사 목록 조회 API", description = "센터에 소속된 요양 보호사를 모두 조회합니다.")
     @ApiResponse(responseCode = "200", description = "요양 보호사 전체 조회 성공")
@@ -88,11 +85,6 @@ public interface CenterController {
     @ApiResponse(responseCode = "200", description = "센터 요양보호사의 서비스 유형 기반 조회 성공")
     @GetMapping("/{centerId}/serviceType")
     ResponseEntity<List<GetCaregiverByServiceTypeResponse>> getCaregiverByServiceType(@PathVariable UUID centerId, @RequestParam Set<ServiceType> serviceTypes);
-
-    @Operation(summary = "요양보호사의 자격증 생성 API", description = "센터 요양보호사의 자격증 정보를 생성합니다.")
-    @ApiResponse(responseCode = "200", description = "센터 요양보호사의 자격증 정보 생성 성공")
-    @PutMapping("/certification")
-    ResponseEntity<Void> createCertification(@RequestBody CreateCertificationRequest request);
 
     @Operation(summary = "요양보호사의 자격증 조회 API", description = "센터 요양보호사의 자격증을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "센터 요양보호사의 자격증 정보 조회 성공")

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
@@ -6,7 +6,6 @@ import jaega.homecare.domain.serviceMatch.dto.res.GetServiceMatchByCenterRespons
 import jaega.homecare.domain.settlement.dto.res.GetDashboardSettlementResponse;
 import jaega.homecare.domain.settlement.dto.res.GetDashboardWorkStatusResponse;
 import jaega.homecare.domain.settlement.service.query.SettlementQueryService;
-import jaega.homecare.domain.caregiver.dto.req.CreateCertificationRequest;
 import jaega.homecare.domain.caregiver.dto.res.GetCertificationResponse;
 import jaega.homecare.domain.caregiver.dto.res.GetDashboardPopularResponse;
 import jaega.homecare.domain.caregiverCenter.entity.CaregiverStatus;
@@ -20,7 +19,6 @@ import jaega.homecare.domain.center.service.command.CenterCommandService;
 import jaega.homecare.domain.serviceMatch.dto.res.GetServiceMatchByUUID;
 import jaega.homecare.domain.serviceMatch.service.query.ServiceMatchQueryService;
 import jaega.homecare.domain.users.entity.ServiceType;
-import jaega.homecare.domain.users.entity.UserRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -53,15 +51,19 @@ public class CenterControllerImpl implements CenterController{
         return ResponseEntity.ok(response);
     }
 
+
     /**
      *
      * 요양보호사 등록 API
      */
+    /*
     @Override
     public ResponseEntity<Void> registerCaregiver(@RequestBody CreateCaregiverRequest createCaregiverRequest, @PathVariable UUID centerId){
-        centerCommandService.registerCaregiver(createCaregiverRequest, UserRole.ROLE_CAREGIVER, centerId);
+        centerCommandService.registerCaregiver(createCaregiverRequest7, UserRole.ROLE_CAREGIVER, centerId);
         return ResponseEntity.noContent().build();
     }
+
+     */
 
     /**
      *
@@ -70,16 +72,6 @@ public class CenterControllerImpl implements CenterController{
     @Override
     public ResponseEntity<Void> deregisterCaregiver(UUID centerId, UUID caregiverId) {
         centerCommandService.deregisterCaregiver(centerId, caregiverId);
-        return ResponseEntity.noContent().build();
-    }
-
-    /**
-     *
-     * 보호사 상세 정보 등록 API
-     */
-    @Override
-    public ResponseEntity<Void> createCaregiverProfile(@RequestBody CreateCaregiverProfileRequest request){
-        caregiverCommandService.createCaregiverProfile(request);
         return ResponseEntity.noContent().build();
     }
 
@@ -158,16 +150,6 @@ public class CenterControllerImpl implements CenterController{
                                                                                              @RequestParam Set<ServiceType> serviceTypes){
         List<GetCaregiverByServiceTypeResponse> responses = caregiverQueryService.getCaregiverByServiceType(centerId, serviceTypes);
         return ResponseEntity.ok(responses);
-    }
-
-    /**
-     *
-     * 요양보호사의 자격증 생성 API
-     */
-    @Override
-    public ResponseEntity<Void> createCertification(@RequestBody CreateCertificationRequest request){
-        certificationCommandService.createCertification(request);
-        return ResponseEntity.noContent().build();
     }
 
     /**

--- a/homecare/src/main/java/jaega/homecare/domain/center/service/command/CenterCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/service/command/CenterCommandService.java
@@ -4,14 +4,11 @@ import jaega.homecare.domain.caregiver.service.command.CaregiverCommandService;
 import jaega.homecare.domain.caregiverCenter.entity.CaregiverCenter;
 import jaega.homecare.domain.caregiverCenter.service.command.CaregiverCenterCommandService;
 import jaega.homecare.domain.center.dto.req.CenterLoginRequest;
-import jaega.homecare.domain.center.dto.req.CreateCaregiverRequest;
 import jaega.homecare.domain.center.dto.res.CenterLoginResponse;
 import jaega.homecare.domain.center.entity.Center;
 import jaega.homecare.domain.center.mapper.CenterMapper;
 import jaega.homecare.domain.center.service.query.CenterQueryService;
-import jaega.homecare.domain.users.dto.req.UserCreateRequest;
 import jaega.homecare.domain.users.entity.User;
-import jaega.homecare.domain.users.entity.UserRole;
 import jaega.homecare.domain.users.repository.UserRepository;
 import jaega.homecare.domain.users.service.command.UserCommandService;
 import jakarta.transaction.Transactional;
@@ -36,6 +33,8 @@ public class CenterCommandService {
     private final CaregiverCommandService caregiverCommandService;
     private final CaregiverCenterCommandService caregiverCenterCommandService;
 
+    // TODO : 추후, 기능 재검토 시 요양보호사 등록이 필요없을 수 있음!
+    /*
     // 요양보호사 등록
     @Transactional
     public void registerCaregiver(CreateCaregiverRequest createCaregiverRequest, UserRole role, UUID centerId) {
@@ -61,6 +60,8 @@ public class CenterCommandService {
 
         caregiverCommandService.createCaregiver(createCaregiverRequest, user, centerId);
     }
+
+     */
 
     // 요양보호사 말소
     @Transactional

--- a/homecare/src/main/java/jaega/homecare/domain/match/processor/CaregiverFilterProcessor.java
+++ b/homecare/src/main/java/jaega/homecare/domain/match/processor/CaregiverFilterProcessor.java
@@ -7,7 +7,6 @@ import jaega.homecare.domain.serviceRequest.entity.ServiceRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -21,15 +20,10 @@ public class CaregiverFilterProcessor {
 
     public List<Caregiver> filter(ServiceRequest request, List<Caregiver> candidates, LocalDate applyDate) {
         return candidates.stream()
-                .filter(c -> !isDayOff(c, applyDate.getDayOfWeek()))
                 .filter(c -> isAvailableAtTime(c, request.getPreferredStartTime(), request.getPreferredEndTime()))
                 .filter(c -> supportsServiceType(c, request.getServiceType()))
                 .filter(c -> !hasOverlappingWork(c, applyDate, request.getPreferredStartTime(), request.getPreferredEndTime()))
                 .collect(Collectors.toList());
-    }
-
-    private boolean isDayOff(Caregiver caregiver, DayOfWeek day) {
-        return caregiver.getDayOfWeek() != null && caregiver.getDayOfWeek().contains(day);
     }
 
     private boolean isAvailableAtTime(Caregiver caregiver, LocalTime start, LocalTime end) {

--- a/homecare/src/main/java/jaega/homecare/domain/match/processor/CaregiverFilterProcessor.java
+++ b/homecare/src/main/java/jaega/homecare/domain/match/processor/CaregiverFilterProcessor.java
@@ -21,7 +21,6 @@ public class CaregiverFilterProcessor {
     public List<Caregiver> filter(ServiceRequest request, List<Caregiver> candidates, LocalDate applyDate) {
         return candidates.stream()
                 .filter(c -> isAvailableAtTime(c, request.getPreferredStartTime(), request.getPreferredEndTime()))
-                .filter(c -> supportsServiceType(c, request.getServiceType()))
                 .filter(c -> !hasOverlappingWork(c, applyDate, request.getPreferredStartTime(), request.getPreferredEndTime()))
                 .collect(Collectors.toList());
     }
@@ -31,9 +30,6 @@ public class CaregiverFilterProcessor {
                 !caregiver.getAvailableEndTime().isBefore(end);
     }
 
-    private boolean supportsServiceType(Caregiver caregiver, ServiceType type) {
-        return caregiver.getServiceTypes().contains(type);
-    }
 
     private boolean hasOverlappingWork(Caregiver caregiver, LocalDate date, LocalTime start, LocalTime end) {
         return !settlementQueryRepository.findOverlappingWorkLog(caregiver, date, start, end).isEmpty();

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/repository/DashboardStats.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/repository/DashboardStats.java
@@ -3,5 +3,6 @@ package jaega.homecare.domain.serviceMatch.repository;
 public record DashboardStats(
         Long totalCaregivers,
         Long assignedCaregivers,
-        Long waitingApplicants
+        Long waitingApplicants,
+        Long unassignedCaregivers
 ) {}

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/repository/ServiceMatchQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/repository/ServiceMatchQueryRepository.java
@@ -10,6 +10,8 @@ import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.caregiver.entity.QCaregiver;
 import jaega.homecare.domain.caregiverCenter.entity.CaregiverStatus;
 import jaega.homecare.domain.caregiverCenter.entity.QCaregiverCenter;
+import jaega.homecare.domain.caregiverPreference.entity.CaregiverPreference;
+import jaega.homecare.domain.caregiverPreference.entity.QCaregiverPreference;
 import jaega.homecare.domain.center.dto.res.GetCaregiverMatchesByMonth;
 import jaega.homecare.domain.consumer.entity.QConsumer;
 import jaega.homecare.domain.recurringOffer.entity.QRecurringOffer;
@@ -157,8 +159,8 @@ public class ServiceMatchQueryRepository {
 
         List<Tuple> result = queryFactory
                 .select(
-                        caregiver.countDistinct(), // 센터의 오늘 매칭이 배정, 완료된 요양보호사 수 조회
-                        ExpressionUtils.as(
+                        caregiver.countDistinct(), // 총 요양보호사 수
+                        ExpressionUtils.as( // 오늘 배정된 요양보호사 수
                                 JPAExpressions
                                         .select(serviceMatch.caregiver.countDistinct())
                                         .from(serviceMatch)
@@ -167,33 +169,47 @@ public class ServiceMatchQueryRepository {
                                         .where(
                                                 caregiverCenter.center.centerId.eq(centerId)
                                                         .and(serviceMatch.serviceDate.eq(date))
-                                                        .and(serviceMatch.matchStatus.in(MatchStatus.PENDING, MatchStatus.CONFIRMED))
-                                        ), "assignedCaregivers"
+                                                        .and(serviceMatch.matchStatus.in(MatchStatus.CONFIRMED))
+                                        ),
+                                "assignedCaregivers"
                         ),
-                        ExpressionUtils.as( // 매칭이 있으나 오늘이 아닌 요양보호사 수 조회
+                        ExpressionUtils.as( // 오늘 이후 배정 대기 중인 요양보호사 수 (PENDING 상태)
                                 JPAExpressions
-                                        .select(serviceMatch.count())
+                                        .select(serviceMatch.caregiver.countDistinct())
                                         .from(serviceMatch)
-                                        .where(serviceMatch.matchStatus.eq(MatchStatus.PENDING)
-                                                .and(serviceMatch.serviceDate.eq(date))), "waitingApplicants"
+                                        .join(serviceMatch.caregiver, caregiver)
+                                        .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
+                                        .where(
+                                                caregiverCenter.center.centerId.eq(centerId)
+                                                        .and(serviceMatch.matchStatus.eq(MatchStatus.PENDING))
+                                                        .and(serviceMatch.serviceDate.goe(date))
+                                        ),
+                                "waitingApplicants"
+                        ),
+                        ExpressionUtils.as( // 오늘 이후 매칭이 없는 미배정 요양보호사 수
+                                JPAExpressions
+                                        .select(caregiver.countDistinct())
+                                        .from(caregiver)
+                                        .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
+                                        .where(
+                                                caregiverCenter.center.centerId.eq(centerId)
+                                                        .and(caregiverCenter.status.eq(CaregiverStatus.ACTIVE))
+                                                        .and(
+                                                                JPAExpressions
+                                                                        .selectOne()
+                                                                        .from(serviceMatch)
+                                                                        .where(
+                                                                                serviceMatch.caregiver.eq(caregiver)
+                                                                                        .and(serviceMatch.serviceDate.goe(date)) // Corrected: Use goe for "on or after today"
+                                                                                        .and(serviceMatch.matchStatus.in(MatchStatus.PENDING, MatchStatus.CONFIRMED))
+                                                                        )
+                                                                        .notExists()
+                                                        )
+                                        ),
+                                "unassignedCaregivers"
                         )
                 )
                 .from(caregiver)
-                .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
-                .where(caregiverCenter.center.centerId.eq(centerId))
-                .fetch();
-
-        Tuple row = result.get(0);
-        return new DashboardStats(row.get(0, Long.class), row.get(1, Long.class), row.get(2, Long.class));
-    }
-    // 요양 보호사 대시보드의 근무지 별 분포 통계 조회
-    public List<WorkPlaceDistribution> getWorkPlaceDistributionByServiceType(UUID centerId) {
-        QCaregiver caregiver = QCaregiver.caregiver;
-        QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
-
-        // 센터 소속 활동 중인 요양보호사 조회 (fetch join으로 serviceTypes 포함)
-        List<Caregiver> caregivers = queryFactory
-                .selectFrom(caregiver)
                 .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
                 .where(
                         caregiverCenter.center.centerId.eq(centerId),
@@ -201,18 +217,51 @@ public class ServiceMatchQueryRepository {
                 )
                 .fetch();
 
-        if (caregivers.isEmpty()) {
+        Tuple row = result.get(0);
+        return new DashboardStats(
+                row.get(0, Long.class), // total caregivers
+                row.get(1, Long.class), // assignedCaregivers
+                row.get(2, Long.class), // waitingApplicants
+                row.get(3, Long.class)  // unassignedCaregivers
+        );
+    }
+
+    // 요양 보호사 대시보드의 근무지 별 분포 통계 조회
+    public List<WorkPlaceDistribution> getWorkPlaceDistributionByServiceType(UUID centerId) {
+        QCaregiver caregiver = QCaregiver.caregiver;
+        QCaregiverCenter caregiverCenter = QCaregiverCenter.caregiverCenter;
+        QCaregiverPreference preference = QCaregiverPreference.caregiverPreference;
+
+        // 센터 소속 활동 중인 요양보호사 + Preference 조회
+        List<Tuple> results = queryFactory
+                .select(caregiver, preference)
+                .from(caregiver)
+                .join(caregiverCenter).on(caregiverCenter.caregiver.eq(caregiver))
+                .leftJoin(preference).on(preference.caregiver.eq(caregiver))
+                .where(
+                        caregiverCenter.center.centerId.eq(centerId),
+                        caregiverCenter.status.eq(CaregiverStatus.ACTIVE)
+                )
+                .fetch();
+
+        if (results.isEmpty()) {
             return Collections.emptyList();
         }
 
-        // ServiceType별 카운트 계산
         Map<ServiceType, Long> serviceTypeCount = new HashMap<>();
-        for (Caregiver cg : caregivers) {
-            Set<ServiceType> serviceTypes = cg.getServiceTypes(); // 이미 Set<ServiceType>
-            if (serviceTypes != null) {
-                for (ServiceType st : serviceTypes) {
-                    serviceTypeCount.put(st, serviceTypeCount.getOrDefault(st, 0L) + 1);
-                }
+
+        for (Tuple tuple : results) {
+            Caregiver cg = tuple.get(caregiver);
+            CaregiverPreference pref = tuple.get(preference);
+
+            // Caregiver + Preference 서비스 타입 합집합
+            Set<ServiceType> combined = new HashSet<>();
+            if (pref.getServiceTypes() != null) combined.addAll(pref.getServiceTypes());
+            if (pref != null && pref.getServiceTypes() != null) combined.addAll(pref.getServiceTypes());
+
+            // 카운트 증가
+            for (ServiceType st : combined) {
+                serviceTypeCount.put(st, serviceTypeCount.getOrDefault(st, 0L) + 1);
             }
         }
 

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/service/query/ServiceMatchQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/service/query/ServiceMatchQueryService.java
@@ -54,20 +54,13 @@ public class ServiceMatchQueryService {
 
     // 대시보드 매칭 스케줄 조회
     public GetDashboardWorkStatusResponse getDashboardWorkStatus(UUID centerId) {
-
         LocalDate today = LocalDate.now();
 
         DashboardStats dashboardStats = serviceMatchQueryRepository.getDashboardStats(centerId, today);
         List<WorkPlaceDistribution> distributions = serviceMatchQueryRepository.getWorkPlaceDistributionByServiceType(centerId);
 
-        Long workingToday = dashboardStats.assignedCaregivers() != null ? dashboardStats.assignedCaregivers() : 0;
-        Long unassignedCaregivers = dashboardStats.totalCaregivers() - workingToday;
-        Long waitingApplicants = dashboardStats.waitingApplicants() != null ? dashboardStats.waitingApplicants() : 0;
-
         return new GetDashboardWorkStatusResponse(
-                workingToday,
-                unassignedCaregivers,
-                waitingApplicants,
+                dashboardStats,
                 distributions
         );
     }

--- a/homecare/src/main/java/jaega/homecare/domain/settlement/dto/res/GetDashboardWorkStatusResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/settlement/dto/res/GetDashboardWorkStatusResponse.java
@@ -1,10 +1,10 @@
 package jaega.homecare.domain.settlement.dto.res;
 
+import jaega.homecare.domain.serviceMatch.repository.DashboardStats;
+
 import java.util.List;
 
 public record GetDashboardWorkStatusResponse(
-        Long workingToday,               // 오늘 근무자
-        Long unassignedCaregivers,       // 미배정 보호사
-        Long waitingApplicants,          // 신청자(배정 대기)
+        DashboardStats dashboardStats,
         List<WorkPlaceDistribution> distribution // 근무지별 분포
 ) {}

--- a/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
+++ b/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
@@ -145,7 +145,6 @@ public class DummyDataService {
                 .address("서울시 송파구 올림픽로 " + index)
           //      .location(new Location(37.514 + random.nextDouble() * 0.1, 86.106 + random.nextDouble() * 0.1))
                 .serviceTypes(serviceTypes)
-                .dayOfWeek(dayOfWeek)
                 .build();
         caregiverRepository.save(caregiver);
 

--- a/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
+++ b/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
@@ -2,11 +2,16 @@ package jaega.homecare.global.dummy.service;
 
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.caregiver.entity.Certification;
+import jaega.homecare.domain.caregiver.entity.KoreanProficiency;
+import jaega.homecare.domain.caregiver.entity.VerifiedStatus;
 import jaega.homecare.domain.caregiver.repository.CaregiverRepository;
 import jaega.homecare.domain.caregiver.repository.CertificationRepository;
 import jaega.homecare.domain.caregiverCenter.entity.CaregiverCenter;
 import jaega.homecare.domain.caregiverCenter.entity.CaregiverStatus;
 import jaega.homecare.domain.caregiverCenter.repository.CaregiverCenterRepository;
+import jaega.homecare.domain.caregiverPreference.entity.CaregiverPreference;
+import jaega.homecare.domain.caregiverPreference.entity.PreferredGender;
+import jaega.homecare.domain.caregiverPreference.repository.CaregiverPreferenceRepository;
 import jaega.homecare.domain.center.entity.Center;
 import jaega.homecare.domain.center.repository.CenterRepository;
 import jaega.homecare.domain.consumer.entity.CognitiveStatus;
@@ -42,6 +47,7 @@ public class DummyDataService {
     private final CaregiverCenterRepository caregiverCenterRepository;
     private final ServiceRequestRepository serviceRequestRepository;
     private final CertificationRepository certificationRepository;
+    private final CaregiverPreferenceRepository caregiverPreferenceRepository;
 
     private final ServiceMatchCommandService serviceMatchCommandService;
     private final SettlementCommandService settlementCommandService;
@@ -106,13 +112,11 @@ public class DummyDataService {
         centerRepository.save(center);
     }
 
-    private void createDummyCaregiver(int index, List<User> caregivers) {
-        // 인덱스 13 예외 해결:
-        // 파라미터로 넘어온 caregivers 리스트를 사용
-        User user = caregivers.get(index);
-
+    private void createDummyCaregiver(int index, List<User> users) {
+        User user = users.get(index);
         Center center = centerRepository.findAll().get(0);
 
+        // 근무 시간 랜덤 생성
         LocalTime startTime, endTime;
         int timeSlot = random.nextInt(3);
         if (timeSlot == 0) {
@@ -126,39 +130,23 @@ public class DummyDataService {
             endTime = LocalTime.of(20, 0);
         }
 
-        Set<ServiceType> serviceTypes = new HashSet<>();
-        serviceTypes.add(ServiceType.values()[random.nextInt(ServiceType.values().length)]);
-        if (random.nextBoolean()) {
-            serviceTypes.add(ServiceType.values()[random.nextInt(ServiceType.values().length)]);
-        }
-
-        Set<DayOfWeek> dayOfWeek = new HashSet<>();
-        if (random.nextBoolean()) {
-            dayOfWeek.add(DayOfWeek.values()[random.nextInt(7)]);
-        }
-
+        // Caregiver 생성
         Caregiver caregiver = Caregiver.builder()
                 .caregiverId(UUID.randomUUID())
                 .user(user)
                 .availableStartTime(startTime)
                 .availableEndTime(endTime)
                 .address("서울시 송파구 올림픽로 " + index)
-          //      .location(new Location(37.514 + random.nextDouble() * 0.1, 86.106 + random.nextDouble() * 0.1))
-                .serviceTypes(serviceTypes)
+                .career(1 + random.nextInt(20)) // 경력 1~20년
+                .koreanProficiency(KoreanProficiency.values()[random.nextInt(KoreanProficiency.values().length)])
+                .isAccompanyOuting(random.nextBoolean())
+                .selfIntroduction("안녕하세요! 요양보호사 " + user.getName() + "입니다.")
+                .verifiedStatus(VerifiedStatus.PENDING)
                 .build();
         caregiverRepository.save(caregiver);
 
-        // 상태 랜덤 생성
-        CaregiverStatus status;
-        int statusRandom = random.nextInt(3);
-        if (statusRandom == 0) {
-            status = CaregiverStatus.ACTIVE;
-        } else if (statusRandom == 1) {
-            status = CaregiverStatus.INACTIVE;
-        } else {
-            status = CaregiverStatus.RESIGNED;
-        }
-
+        // CaregiverCenter 생성 (상태 랜덤)
+        CaregiverStatus status = CaregiverStatus.values()[random.nextInt(CaregiverStatus.values().length)];
         CaregiverCenter caregiverCenter = CaregiverCenter.builder()
                 .caregiverCenterId(UUID.randomUUID())
                 .caregiver(caregiver)
@@ -167,11 +155,56 @@ public class DummyDataService {
                 .build();
         caregiverCenterRepository.save(caregiverCenter);
 
+        // 서비스 타입 랜덤
+        Set<ServiceType> serviceTypes = new HashSet<>();
+        serviceTypes.add(ServiceType.values()[random.nextInt(ServiceType.values().length)]);
+        if (random.nextBoolean()) {
+            serviceTypes.add(ServiceType.values()[random.nextInt(ServiceType.values().length)]);
+        }
+
+        // 근무 가능 요일 랜덤
+        Set<DayOfWeek> dayOfWeek = new HashSet<>();
+        int numDays = 1 + random.nextInt(5); // 1~5일 랜덤
+        while (dayOfWeek.size() < numDays) {
+            dayOfWeek.add(DayOfWeek.values()[random.nextInt(7)]);
+        }
+
+        // 지원 가능 질환 랜덤
+        Set<Disease> supportedConditions = new HashSet<>();
+        if (random.nextBoolean()) supportedConditions.add(Disease.DEMENTIA); // 치매
+        if (random.nextBoolean()) supportedConditions.add(Disease.BEDRIDDEN); // 와상
+
+        // CaregiverPreference 생성
+        CaregiverPreference preference = CaregiverPreference.builder()
+                .caregiverPreferenceId(UUID.randomUUID())
+                .caregiver(caregiver)
+                .serviceTypes(serviceTypes)
+                .dayOfWeek(dayOfWeek)
+                .workStartTime(startTime)
+                .workEndTime(endTime)
+                .workMinTime(2 + random.nextInt(2))      // 최소 근무시간 2~3시간
+                .workMaxTime(4 + random.nextInt(4))      // 최대 근무시간 4~7시간
+                .availableTime(30 + random.nextInt(91))  // 이동 가능 시간 30~120분
+                .workArea("서울시 송파구")                // 근무 가능 지역
+                .transportation(random.nextBoolean() ? "자가차량" : "대중교통")
+                .lunchBreak(30)                           // 점심시간 30분
+                .bufferTime(15)                           // 이동 시간 제외 버퍼 15분
+                .supportedConditions(supportedConditions)
+                .preferredMinAge(40 + random.nextInt(20))  // 선호 최소 연령 40~59
+                .preferredMaxAge(60 + random.nextInt(20))  // 선호 최대 연령 60~79
+                .preferredGender(PreferredGender.values()[random.nextInt(PreferredGender.values().length)])
+                .build();
+
+        caregiverPreferenceRepository.save(preference);
+
+        // Certification 생성 (기존 유지)
         Certification certification = Certification.builder()
                 .certificationId(UUID.randomUUID())
                 .caregiver(caregiver)
                 .certificationNumber("CERT-2025-" + String.format("%04d", index))
-                .certificationDate(LocalDate.of(2020 + random.nextInt(5), random.nextInt(12) + 1, random.nextInt(28) + 1))
+                .certificationDate(LocalDate.of(2020 + random.nextInt(5),
+                        1 + random.nextInt(12),
+                        1 + random.nextInt(28)))
                 .trainStatus(random.nextBoolean())
                 .build();
         certificationRepository.save(certification);

--- a/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
+++ b/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
@@ -143,7 +143,7 @@ public class DummyDataService {
                 .availableStartTime(startTime)
                 .availableEndTime(endTime)
                 .address("서울시 송파구 올림픽로 " + index)
-                .location(new Location(37.514 + random.nextDouble() * 0.1, 86.106 + random.nextDouble() * 0.1))
+          //      .location(new Location(37.514 + random.nextDouble() * 0.1, 86.106 + random.nextDouble() * 0.1))
                 .serviceTypes(serviceTypes)
                 .dayOfWeek(dayOfWeek)
                 .build();


### PR DESCRIPTION
## #️⃣연관된 이슈

> #33 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 1. 요양보호사의 회원가입 API를 구현했습니다.
- 변경된 erd에 맞게 요양보호사 도메인을 수정하고 회원가입 API를 구현했습니다.

### 2. 요양보호사의 선호(근무) 조건 관련 API를 구현했습니다.
- 요양보호사의 선호(근무) 조건 작성, 조회 API를 구현했습니다.
- erd에 맞게 서비스 타입 속성을 요양보호사 -> 선호(근무) 조건으로 변경했습니다.

### 3. 제출된 프로필/자격증 심사 대기를 위한 화면 API를 구현했습니다.
- 단순히 요양보호사의 관리자 승인 상태를 조회하는 API를 추가하여 리턴하도록 했습니다.
(인증 기능 구현 시 관리자 승인 상태가 아닐 경우 다른 페이지로 이동 못 하도록 CORS 도입 고려)

### 4. 센터 대시보드에서 잘못된 count를 하던 점을 수정했습니다.
(ServiceType 구조 변경으로 인한 코드 검증 과정에서 발생했습니다.)
- 의도와는 달리 매우 이상하게 count를 하여 제대로 기능을 수행하지 못하던 점을 수정했습니다.
(센터의 '모든'(등록 상태 상관없이) 상태 조회 및 의도와는 매우 다른 수를 조회했습니다.)
- 센터 대시보드는 이제 다음과 같은 리턴 타입을 가집니다.
**예시**
```
{
  "dashboardStats": {
    "totalCaregivers": 11,         // 총 요양보호사 수
    "assignedCaregivers": 3,  // 배정된 요양보호사 수 ( 오늘)
    "waitingApplicants": 8,     // 대기중인 요양보호사 수 (PENDING 상태인 요양보호사)
    "unassignedCaregivers": 1 // 아예 매칭이 되지 않은 요양보호사 ( 오늘 이후로 PENDING, CONFIRMED도 없음)
  },
  "distribution": [
    {
      "serviceType": "VISITING_BATH",
      "count": 4,
      "percent": 25
    },
    {
      "serviceType": "VISITING_CARE",
      "count": 1,
      "percent": 6.3
    },
    {
      "serviceType": "VISITING_NURSING",
      "count": 4,
      "percent": 25
    },
    {
      "serviceType": "IN_HOME_SUPPORT",
      "count": 4,
      "percent": 25
    },
    {
      "serviceType": "RESPITE_CARE",
      "count": 3,
      "percent": 18.8
    }
  ]
}
```

### 스크린샷 (선택)

<br>

## 💬리뷰 요구사항(선택)

### 요양보호사 '도메인'의 'serviceTypes'를 조회하는 서비스들의 코드가 매우 복잡합니다,,
(해당 사항 : Center 도메인)
복잡한 이유는 사실 기존 요양보호사 도메인에서 serviceTypes를 조회하기만 하면 됐었습니다.
그러나, serviceTypes가 CaregiverPreference 도메인으로 이동되면서 서비스 타입을 조회하기 위해 좀 먼 길을 돌아가게 되었습니다.
코드 리뷰 하실 때 참고하시면 될 것 같습니다,, !! 

### 센터 대시보드 조회에 오늘 '이후'로 배정된 요양보호사 조회도 추가할까요?
대시보드 조회엔 오늘'만' 배정된 요양보호사의 수를 조회하고 이후는 조회하는 것이 없습니다.
그렇기에 관리자 입장에선 오늘 이후로 배정된 요양보호사 수를 알 수가 없습니다.
오늘 '이후'로 배정된 요양 보호사의 수를 조회하는 속성을 추가하는 게 좋을까요?
