### PR TITLE
[#46] Caregiver 기관 소속 등록, 마이페이지 API 구현 및 로그인 API 통합

### DIFF
--- a/homecare/src/main/java/jaega/homecare/domain/blacklist/entity/Blacklist.java
+++ b/homecare/src/main/java/jaega/homecare/domain/blacklist/entity/Blacklist.java
@@ -27,7 +27,7 @@ public class Blacklist extends BaseTimeEntity {
     private Caregiver caregiver;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "consumer_id")
     private Consumer consumer;
 
     @Builder

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverController.java
@@ -6,11 +6,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jaega.homecare.domain.caregiver.dto.req.CaregiverSignupRequest;
 import jaega.homecare.domain.caregiver.dto.req.ChoiceCaregiverCenterRequest;
+import jaega.homecare.domain.caregiver.dto.res.CaregiverLoginResponse;
 import jaega.homecare.domain.caregiver.dto.res.GetCaregiverSignupResponse;
 import jaega.homecare.domain.caregiver.dto.res.GetCaregiverVerifiedStatusResponse;
 import jaega.homecare.domain.caregiver.dto.res.SelectableCaregiverCenter;
 import jaega.homecare.domain.serviceMatch.dto.res.CaregiverScheduleDetailResponse;
 import jaega.homecare.domain.serviceMatch.dto.res.CaregiverScheduleResponse;
+import jaega.homecare.domain.users.dto.req.UserLoginRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,6 +28,9 @@ public interface CaregiverController {
     @ApiResponse(responseCode = "204", description = "요양보호사의 회원가입 성공")
     @PostMapping("/register")
     ResponseEntity<GetCaregiverSignupResponse> signupCaregiver(@RequestBody CaregiverSignupRequest request);
+
+    @PostMapping("/login")
+    ResponseEntity<CaregiverLoginResponse> loginCaregiver(@RequestBody UserLoginRequest request);
 
     @Operation(summary = "요양보호사 승인 상태 조회 API", description = "회원가입 후, 기관 선택으로 이동하기 전 승인 검증을 위해 승인 상태를 조회합니다.<br>" +
             "RequestParam으로 한 이유는, 추후 JWT 인증 로직 구현 시 대체를 편하게 하기 위함입니다.")

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverController.java
@@ -90,12 +90,16 @@ public interface CaregiverController {
     @GetMapping("/home/next-schedule")
     ResponseEntity<List<CaregiverScheduleResponse>> getTomorrowSchedule(@RequestParam UUID caregiverId);
 
+    /**
+     *
+     * 리뷰 조회 API
+     */
 
     @Operation(summary = "요양보호사에게 신청자가 남긴 리뷰 리스트 조회", description = "요양보호사를 대상으로 신청자가 남긴 리뷰들을 조회합니다.<br>" +
             "평균 점수가 계산되고, 리뷰 리스트들이 조회됩니다.")
     @ApiResponse(responseCode = "200", description = "요양보호사에게 등록된 리뷰 리스트 조회 성공")
     @GetMapping("/review")
-    ResponseEntity<CaregiverReviewSummaryResponse> getReviews(@PathVariable UUID caregiverId);
+    ResponseEntity<CaregiverReviewSummaryResponse> getReviews(@RequestParam UUID caregiverId);
 
     @Operation(summary = "요양보호사에게 등록된 리뷰 상세 조회", description = "요양보호사에게 등록된 특정 리뷰를 상세 조회합니다.")
     @ApiResponse(responseCode = "200", description = "요양보호사에게 등록된 리뷰 상세 조회 성공")

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverController.java
@@ -12,6 +12,8 @@ import jaega.homecare.domain.caregiver.dto.res.GetCaregiverVerifiedStatusRespons
 import jaega.homecare.domain.caregiver.dto.res.SelectableCaregiverCenter;
 import jaega.homecare.domain.serviceMatch.dto.res.CaregiverScheduleDetailResponse;
 import jaega.homecare.domain.serviceMatch.dto.res.CaregiverScheduleResponse;
+import jaega.homecare.domain.review.dto.res.CaregiverReviewDetailResponse;
+import jaega.homecare.domain.review.dto.res.CaregiverReviewSummaryResponse;
 import jaega.homecare.domain.users.dto.req.UserLoginRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -29,6 +31,8 @@ public interface CaregiverController {
     @PostMapping("/register")
     ResponseEntity<GetCaregiverSignupResponse> signupCaregiver(@RequestBody CaregiverSignupRequest request);
 
+    @Operation(summary = "요양보호사 로그인 API", description = "입력받은 정보로 요양보호사의 로그인을 진행합니다.")
+    @ApiResponse(responseCode = "200", description = "요양보호사 로그인 성공")
     @PostMapping("/login")
     ResponseEntity<CaregiverLoginResponse> loginCaregiver(@RequestBody UserLoginRequest request);
 
@@ -86,4 +90,15 @@ public interface CaregiverController {
     @GetMapping("/home/next-schedule")
     ResponseEntity<List<CaregiverScheduleResponse>> getTomorrowSchedule(@RequestParam UUID caregiverId);
 
+
+    @Operation(summary = "요양보호사에게 신청자가 남긴 리뷰 리스트 조회", description = "요양보호사를 대상으로 신청자가 남긴 리뷰들을 조회합니다.<br>" +
+            "평균 점수가 계산되고, 리뷰 리스트들이 조회됩니다.")
+    @ApiResponse(responseCode = "200", description = "요양보호사에게 등록된 리뷰 리스트 조회 성공")
+    @GetMapping("/review")
+    ResponseEntity<CaregiverReviewSummaryResponse> getReviews(@PathVariable UUID caregiverId);
+
+    @Operation(summary = "요양보호사에게 등록된 리뷰 상세 조회", description = "요양보호사에게 등록된 특정 리뷰를 상세 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "요양보호사에게 등록된 리뷰 상세 조회 성공")
+    @GetMapping("/review/{reviewId}")
+    ResponseEntity<CaregiverReviewDetailResponse> getReviewDetail(@PathVariable UUID reviewId);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverControllerImpl.java
@@ -134,9 +134,13 @@ public class CaregiverControllerImpl implements CaregiverController {
         return ResponseEntity.ok(responses);
     }
 
+    /**
+     *  리뷰 조회 API
+     *
+     */
 
     @Override
-    public ResponseEntity<CaregiverReviewSummaryResponse> getReviews(@PathVariable UUID caregiverId) {
+    public ResponseEntity<CaregiverReviewSummaryResponse> getReviews(@RequestParam UUID caregiverId) {
         CaregiverReviewSummaryResponse response = reviewQueryService.getReviewsForCaregiver(caregiverId);
         return ResponseEntity.ok(response);
     }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverControllerImpl.java
@@ -12,6 +12,9 @@ import jaega.homecare.domain.caregiverCenter.entity.CaregiverCenter;
 import jaega.homecare.domain.caregiverCenter.service.query.CaregiverCenterQueryService;
 import jaega.homecare.domain.serviceMatch.dto.res.CaregiverScheduleDetailResponse;
 import jaega.homecare.domain.serviceMatch.dto.res.CaregiverScheduleResponse;
+import jaega.homecare.domain.review.dto.res.CaregiverReviewDetailResponse;
+import jaega.homecare.domain.review.dto.res.CaregiverReviewSummaryResponse;
+import jaega.homecare.domain.review.service.query.ReviewQueryService;
 import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
 import jaega.homecare.domain.serviceMatch.service.query.ServiceMatchQueryService;
 import jaega.homecare.domain.settlement.dto.req.CreateSettlementRequest;
@@ -35,6 +38,7 @@ public class CaregiverControllerImpl implements CaregiverController {
     private final CaregiverCenterQueryService caregiverCenterQueryService;
     private final CaregiverCommandService caregiverCommandService;
     private final CaregiverQueryService caregiverQueryService;
+    private final ReviewQueryService reviewQueryService;
 
     // 요양보호사 회원가입
     @Override
@@ -131,4 +135,15 @@ public class CaregiverControllerImpl implements CaregiverController {
     }
 
 
+    @Override
+    public ResponseEntity<CaregiverReviewSummaryResponse> getReviews(@PathVariable UUID caregiverId) {
+        CaregiverReviewSummaryResponse response = reviewQueryService.getReviewsForCaregiver(caregiverId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<CaregiverReviewDetailResponse> getReviewDetail(@PathVariable UUID reviewId) {
+        CaregiverReviewDetailResponse response = reviewQueryService.getReviewDetail(reviewId);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverControllerImpl.java
@@ -1,9 +1,8 @@
 package jaega.homecare.domain.caregiver.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jaega.homecare.domain.caregiver.dto.req.CaregiverSignupRequest;
 import jaega.homecare.domain.caregiver.dto.req.ChoiceCaregiverCenterRequest;
+import jaega.homecare.domain.caregiver.dto.res.CaregiverLoginResponse;
 import jaega.homecare.domain.caregiver.dto.res.GetCaregiverSignupResponse;
 import jaega.homecare.domain.caregiver.dto.res.GetCaregiverVerifiedStatusResponse;
 import jaega.homecare.domain.caregiver.dto.res.SelectableCaregiverCenter;
@@ -17,6 +16,7 @@ import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
 import jaega.homecare.domain.serviceMatch.service.query.ServiceMatchQueryService;
 import jaega.homecare.domain.settlement.dto.req.CreateSettlementRequest;
 import jaega.homecare.domain.settlement.service.command.SettlementCommandService;
+import jaega.homecare.domain.users.dto.req.UserLoginRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -40,6 +40,13 @@ public class CaregiverControllerImpl implements CaregiverController {
     @Override
     public ResponseEntity<GetCaregiverSignupResponse> signupCaregiver(@RequestBody CaregiverSignupRequest request){
         GetCaregiverSignupResponse response = caregiverCommandService.signupCaregiver(request);
+        return ResponseEntity.ok(response);
+    }
+
+    // 요양보호사 로그인
+    @Override
+    public ResponseEntity<CaregiverLoginResponse> loginCaregiver(@RequestBody UserLoginRequest request){
+        CaregiverLoginResponse response = caregiverCommandService.loginCaregiver(request);
         return ResponseEntity.ok(response);
     }
 

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/dto/req/CaregiverLoginRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/dto/req/CaregiverLoginRequest.java
@@ -1,0 +1,7 @@
+package jaega.homecare.domain.caregiver.dto.req;
+
+public record CaregiverLoginRequest(
+        String email,
+        String password
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/dto/res/CaregiverLoginResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/dto/res/CaregiverLoginResponse.java
@@ -1,0 +1,8 @@
+package jaega.homecare.domain.caregiver.dto.res;
+
+import java.util.UUID;
+
+public record CaregiverLoginResponse(
+        UUID caregiverId
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
@@ -42,6 +42,7 @@ public class Caregiver extends BaseTimeEntity {
     private String selfIntroduction;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "verified_status")
     private VerifiedStatus verifiedStatus;
 
     @Builder

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Certification.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Certification.java
@@ -24,10 +24,13 @@ public class Certification {
     @JoinColumn(name = "caregiver_id")
     private Caregiver caregiver;
 
+    @Column(name = "certification_number")
     private String CertificationNumber;
 
+    @Column(name = "certification_date")
     private LocalDate CertificationDate;
 
+    @Column(name = "train_status")
     private boolean trainStatus;
 
     @Builder

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/mapper/CaregiverMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/mapper/CaregiverMapper.java
@@ -1,6 +1,7 @@
 package jaega.homecare.domain.caregiver.mapper;
 
 import jaega.homecare.domain.caregiver.dto.req.CaregiverCreateRequest;
+import jaega.homecare.domain.caregiver.dto.res.CaregiverLoginResponse;
 import jaega.homecare.domain.caregiver.dto.res.GetCaregiverSignupResponse;
 import jaega.homecare.domain.caregiver.dto.res.GetCaregiverVerifiedStatusResponse;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
@@ -36,4 +37,6 @@ public interface CaregiverMapper {
     @Mapping(target = "phone", source = "caregiver.user.phone")
     @Mapping(target = "serviceTypes", source = "preference.serviceTypes")
     GetCaregiverProfileResponse toGetCaregiverProfile(Caregiver caregiver, CaregiverPreference preference);
+
+    CaregiverLoginResponse toLoginResponse(Caregiver caregiver);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverQueryRepository.java
@@ -1,14 +1,17 @@
 package jaega.homecare.domain.caregiver.repository;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.domain.caregiver.entity.QCertification;
 import jaega.homecare.domain.caregiverCenter.entity.CaregiverCenter;
 import jaega.homecare.domain.caregiverCenter.entity.CaregiverStatus;
 import jaega.homecare.domain.caregiver.entity.QCaregiver;
 import jaega.homecare.domain.caregiverPreference.entity.CaregiverPreference;
 import jaega.homecare.domain.caregiverPreference.entity.QCaregiverPreference;
+import jaega.homecare.domain.center.dto.req.SearchCaregiverResponse;
 import jaega.homecare.domain.center.entity.Center;
 import jaega.homecare.domain.caregiverCenter.entity.QCaregiverCenter;
 import jaega.homecare.domain.users.entity.ServiceType;
@@ -182,6 +185,26 @@ public class CaregiverQueryRepository {
                 .from(caregiver)
                 .leftJoin(pref).on(pref.caregiver.eq(caregiver))
                 .where(caregiver.caregiverId.in(caregiverIds))
+                .fetch();
+    }
+
+    public List<SearchCaregiverResponse> searchByNameOrPhone(String keyword) {
+        QCaregiver caregiver = QCaregiver.caregiver;
+        QUser user = QUser.user;
+        QCertification certification = QCertification.certification;
+
+        return queryFactory
+                .select(Projections.constructor(SearchCaregiverResponse.class,
+                        caregiver.caregiverId,
+                        user.name,
+                        user.phone,
+                        certification.CertificationNumber
+                ))
+                .from(caregiver)
+                .join(caregiver.user, user)
+                .leftJoin(certification).on(certification.caregiver.eq(caregiver))
+                .where(user.name.containsIgnoreCase(keyword)
+                        .or(user.phone.containsIgnoreCase(keyword)))
                 .fetch();
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/repository/CaregiverRepository.java
@@ -1,6 +1,7 @@
 package jaega.homecare.domain.caregiver.repository;
 
 import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.domain.users.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +9,6 @@ import java.util.UUID;
 
 public interface CaregiverRepository extends JpaRepository<Caregiver, Long>{
     Optional<Caregiver> findByCaregiverId(UUID caregiverId);
+
+    Caregiver findByUser(User user);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/service/command/CaregiverCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/service/command/CaregiverCommandService.java
@@ -2,15 +2,19 @@ package jaega.homecare.domain.caregiver.service.command;
 
 import jaega.homecare.domain.caregiver.dto.req.CaregiverSignupRequest;
 import jaega.homecare.domain.caregiver.dto.req.CaregiverCreateRequest;
+import jaega.homecare.domain.caregiver.dto.res.CaregiverLoginResponse;
 import jaega.homecare.domain.caregiver.dto.res.GetCaregiverSignupResponse;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.caregiver.repository.CaregiverRepository;
 import jaega.homecare.domain.caregiver.mapper.CaregiverMapper;
+import jaega.homecare.domain.users.dto.req.UserLoginRequest;
 import jaega.homecare.domain.users.entity.User;
 import jaega.homecare.domain.users.entity.UserRole;
 import jaega.homecare.domain.users.service.command.UserCommandService;
+import jaega.homecare.domain.users.service.query.UserQueryService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
@@ -37,6 +41,13 @@ public class CaregiverCommandService {
         caregiver.initializeCaregiver(UUID.randomUUID());
 
         return caregiverRepository.save(caregiver);
+    }
+
+    public CaregiverLoginResponse loginCaregiver(UserLoginRequest request){
+        User user = userCommandService.loginUser(request);
+        Caregiver caregiver = caregiverRepository.findByUser(user);
+        if(caregiver == null) throw new BadCredentialsException("로그인에 실패했습니다.");
+        return caregiverMapper.toLoginResponse(caregiver);
     }
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/service/query/CaregiverQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/service/query/CaregiverQueryService.java
@@ -9,6 +9,7 @@ import jaega.homecare.domain.caregiver.repository.CaregiverQueryRepository;
 import jaega.homecare.domain.caregiver.repository.CaregiverRepository;
 import jaega.homecare.domain.caregiverPreference.entity.CaregiverPreference;
 import jaega.homecare.domain.caregiverPreference.service.query.CaregiverPreferenceQueryService;
+import jaega.homecare.domain.center.dto.req.SearchCaregiverResponse;
 import jaega.homecare.domain.center.dto.res.GetCaregiverByCaregiverStatusResponse;
 import jaega.homecare.domain.center.dto.res.GetCaregiverByServiceTypeResponse;
 import jaega.homecare.domain.center.dto.res.GetCaregiverProfileResponse;
@@ -16,7 +17,9 @@ import jaega.homecare.domain.center.dto.res.GetCaregiverResponse;
 import jaega.homecare.domain.center.entity.Center;
 import jaega.homecare.domain.center.service.query.CenterQueryService;
 import jaega.homecare.domain.users.entity.ServiceType;
+import jaega.homecare.domain.users.service.query.UserQueryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -28,17 +31,21 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class CaregiverQueryService {
 
+    private final PasswordEncoder passwordEncoder;
+    private final UserQueryService userQueryService;
     private final CenterQueryService centerQueryService;
     private final CaregiverPreferenceQueryService caregiverPreferenceQueryService;
     private final CaregiverQueryRepository caregiverQueryRepository;
     private final CaregiverRepository caregiverRepository;
     private final CaregiverMapper caregiverMapper;
 
+    // 도메인 조회용
     public Caregiver getCaregiver(UUID caregiverId){
         return caregiverRepository.findByCaregiverId(caregiverId)
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 요양보호사입니다."));
     }
 
+    // 요양보호사 관리자 인증 상태 조회
     /**
      *
      * Caregiver
@@ -57,25 +64,30 @@ public class CaregiverQueryService {
      *
      */
 
+    // 센터의 모든 요양보호사 조회
     public List<GetCaregiverResponse> getAllCaregiversByCenter(UUID centerId) {
         return caregiverQueryRepository.findAllByCenterId(centerId);
     }
 
+    // 센터의 요양보호사 상태 기반 조회
     public List<GetCaregiverByCaregiverStatusResponse> getCaregiverByWorkStatus(UUID centerId, CaregiverStatus status){
         return caregiverQueryRepository.findCaregiverByCaregiverStatus(centerId, status);
     }
 
+    // 센터의 요양보호사 서비스 타입별 조회
     public List<GetCaregiverByServiceTypeResponse> getCaregiverByServiceType(UUID centerId, Set<ServiceType> serviceTypes){
         return caregiverQueryRepository.findCaregiverByServiceTypes(centerId, serviceTypes);
     }
 
+    // 요양보호사 프로필 정보 조회
     public GetCaregiverProfileResponse getCaregiverProfile(UUID caregiverId){
         Caregiver caregiver = getCaregiver(caregiverId);
         CaregiverPreference caregiverPreference = caregiverPreferenceQueryService.findCaregiverPreferenceByCaregiver(caregiverId);
         return caregiverMapper.toGetCaregiverProfile(caregiver, caregiverPreference);
     }
 
-    public GetDashboardPopularResponse getCaregiverStatus(UUID centerId) {
+    // 센터 대시보드 통계 조회
+    public GetDashboardPopularResponse getCaregiverStats(UUID centerId) {
         Center center = centerQueryService.findCenterByUUID(centerId);
 
         Long total = caregiverQueryRepository.countByCenterId(center.getCenterId());
@@ -85,6 +97,11 @@ public class CaregiverQueryService {
         Long newThisMonth = caregiverQueryRepository.countNewCaregiversThisMonth(center);
 
         return new GetDashboardPopularResponse(total, active, inactive, resigned, newThisMonth);
+    }
+
+    // 센터의 소속 등록을 위한 요양보호사 검색
+    public List<SearchCaregiverResponse> searchCaregiver(String keyword){
+        return caregiverQueryRepository.searchByNameOrPhone(keyword);
     }
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverCenter/dto/req/CreateCaregiverCenterRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverCenter/dto/req/CreateCaregiverCenterRequest.java
@@ -1,0 +1,9 @@
+package jaega.homecare.domain.caregiverCenter.dto.req;
+
+import java.util.UUID;
+
+public record CreateCaregiverCenterRequest(
+        UUID caregiverId,
+        UUID centerId
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverCenter/entity/CaregiverCenter.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverCenter/entity/CaregiverCenter.java
@@ -32,8 +32,11 @@ public class CaregiverCenter {
     private Center center;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "caregiver_status")
     private CaregiverStatus status;
 
+    // TODO : basetimeEntity로 대체?
+    @Column(name = "joined_at")
     private LocalDateTime joinedAt;
 
     @Builder

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverCenter/entity/CaregiverCenter.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverCenter/entity/CaregiverCenter.java
@@ -2,19 +2,19 @@ package jaega.homecare.domain.caregiverCenter.entity;
 
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.center.entity.Center;
+import jaega.homecare.global.audit.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
 @Getter
 @Table(name = "caregiver_center")
 @NoArgsConstructor
-public class CaregiverCenter {
+public class CaregiverCenter extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -35,23 +35,17 @@ public class CaregiverCenter {
     @Column(name = "caregiver_status")
     private CaregiverStatus status;
 
-    // TODO : basetimeEntity로 대체?
-    @Column(name = "joined_at")
-    private LocalDateTime joinedAt;
-
     @Builder
-    public CaregiverCenter(UUID caregiverCenterId, Caregiver caregiver, Center center, CaregiverStatus status, LocalDateTime joinedAt){
+    public CaregiverCenter(UUID caregiverCenterId, Caregiver caregiver, Center center, CaregiverStatus status){
         this.caregiverCenterId = caregiverCenterId;
         this.caregiver = caregiver;
         this.center = center;
         this.status = status;
-        this.joinedAt = joinedAt;
     }
 
-    public void setCaregiverCenter(UUID caregiverCenterId, CaregiverStatus status, LocalDateTime joinedAt){
+    public void setCaregiverCenter(UUID caregiverCenterId, CaregiverStatus status){
         this.caregiverCenterId = caregiverCenterId;
         this.status = status;
-        this.joinedAt = joinedAt;
     }
 
     public void deregister() {

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverCenter/mapper/CaregiverCenterMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverCenter/mapper/CaregiverCenterMapper.java
@@ -11,6 +11,5 @@ public interface CaregiverCenterMapper {
 
     @Mapping(target = "caregiverCenterId", ignore = true)
     @Mapping(target = "status", ignore = true)
-    @Mapping(target = "joinedAt", ignore = true)
     CaregiverCenter toEntity(Caregiver caregiver, Center center);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/caregiverCenter/service/command/CaregiverCenterCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiverCenter/service/command/CaregiverCenterCommandService.java
@@ -23,7 +23,7 @@ public class CaregiverCenterCommandService {
 
     public void createCaregiverCenter(Center center, Caregiver caregiver){
         CaregiverCenter caregiverCenter = caregiverCenterMapper.toEntity(caregiver, center);
-        caregiverCenter.setCaregiverCenter(UUID.randomUUID(), CaregiverStatus.ACTIVE, LocalDateTime.now());
+        caregiverCenter.setCaregiverCenter(UUID.randomUUID(), CaregiverStatus.ACTIVE);
 
         caregiverCenterRepository.save(caregiverCenter);
     }

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
@@ -3,6 +3,7 @@ package jaega.homecare.domain.center.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jaega.homecare.domain.caregiverCenter.dto.req.CreateCaregiverCenterRequest;
 import jaega.homecare.domain.center.dto.res.GetCaregiverMatchesByMonth;
 import jaega.homecare.domain.center.dto.res.GetCaregiverMatchesResponse;
 import jaega.homecare.domain.serviceMatch.dto.res.GetServiceMatchByCenterResponse;
@@ -46,6 +47,12 @@ public interface CenterController {
     ResponseEntity<List<SearchCaregiverResponse>> searchCaregiver(
             @RequestParam String keyword
     );
+
+    @Operation(summary = "센터의 요양보호사 기관 등록 API", description = "해당 요양보호사를 기관에 등록합니다.")
+    @ApiResponse(responseCode = "204", description = "요양 보호사 등록 성공")
+    @PostMapping("/caregiver/register")
+    ResponseEntity<Void> registerCaregiver(@RequestBody CreateCaregiverCenterRequest request);
+
     @Operation(summary = "요양 보호사 말소 API", description = "입력받은 센터 ID와 보호사 ID를 이용하여 해당 요양 보호사를 말소(삭제)합니다.")
     @ApiResponse(responseCode = "204", description = "요양 보호사 말소 성공")
     @DeleteMapping("/{centerId}/caregiver/{caregiverId}")

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterController.java
@@ -40,6 +40,12 @@ public interface CenterController {
 
      */
 
+    @Operation(summary = "요양 보호사 검색 API", description = "센터에 등록하기 위해 이름, 전화번호 중 하나로 요양보호사를 검색합니다.")
+    @ApiResponse(responseCode = "200", description = "요양 보호사 검색 성공")
+    @GetMapping("/caregiver/search")
+    ResponseEntity<List<SearchCaregiverResponse>> searchCaregiver(
+            @RequestParam String keyword
+    );
     @Operation(summary = "요양 보호사 말소 API", description = "입력받은 센터 ID와 보호사 ID를 이용하여 해당 요양 보호사를 말소(삭제)합니다.")
     @ApiResponse(responseCode = "204", description = "요양 보호사 말소 성공")
     @DeleteMapping("/{centerId}/caregiver/{caregiverId}")

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
@@ -78,6 +78,14 @@ public class CenterControllerImpl implements CenterController{
         return ResponseEntity.ok(responses);
     }
 
+    @Override
+    public ResponseEntity<Void> registerCaregiver(@RequestBody CreateCaregiverCenterRequest request){
+        Caregiver caregiver = caregiverQueryService.getCaregiver(request.caregiverId());
+        Center center = centerQueryService.findCenterByUUID(request.centerId());
+        caregiverCenterCommandService.createCaregiverCenter(center, caregiver);
+        return ResponseEntity.noContent().build();
+    }
+
     /**
      *
      * 요양 보호사 말소 API

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
@@ -70,6 +70,7 @@ public class CenterControllerImpl implements CenterController{
 
      */
 
+    // 요양보호사 검색 API
     @Override
     public ResponseEntity<List<SearchCaregiverResponse>> searchCaregiver(
             @RequestParam String keyword

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
@@ -1,7 +1,12 @@
 package jaega.homecare.domain.center.controller;
 
+import jaega.homecare.domain.caregiver.entity.Caregiver;
+import jaega.homecare.domain.caregiverCenter.dto.req.CreateCaregiverCenterRequest;
+import jaega.homecare.domain.caregiverCenter.service.command.CaregiverCenterCommandService;
 import jaega.homecare.domain.center.dto.res.GetCaregiverMatchesByMonth;
 import jaega.homecare.domain.center.dto.res.GetCaregiverMatchesResponse;
+import jaega.homecare.domain.center.entity.Center;
+import jaega.homecare.domain.center.service.query.CenterQueryService;
 import jaega.homecare.domain.serviceMatch.dto.res.GetServiceMatchByCenterResponse;
 import jaega.homecare.domain.settlement.dto.res.GetDashboardSettlementResponse;
 import jaega.homecare.domain.settlement.dto.res.GetDashboardWorkStatusResponse;
@@ -9,7 +14,6 @@ import jaega.homecare.domain.settlement.service.query.SettlementQueryService;
 import jaega.homecare.domain.caregiver.dto.res.GetCertificationResponse;
 import jaega.homecare.domain.caregiver.dto.res.GetDashboardPopularResponse;
 import jaega.homecare.domain.caregiverCenter.entity.CaregiverStatus;
-import jaega.homecare.domain.caregiver.service.command.CaregiverCommandService;
 import jaega.homecare.domain.caregiver.service.command.CertificationCommandService;
 import jaega.homecare.domain.caregiver.service.query.CaregiverQueryService;
 import jaega.homecare.domain.caregiver.service.query.CertificationQueryService;
@@ -33,7 +37,8 @@ import java.util.UUID;
 public class CenterControllerImpl implements CenterController{
 
     private final CenterCommandService centerCommandService;
-    private final CaregiverCommandService caregiverCommandService;
+    private final CenterQueryService centerQueryService;
+    private final CaregiverCenterCommandService caregiverCenterCommandService;
     private final CaregiverQueryService caregiverQueryService;
     private final ServiceMatchQueryService serviceMatchQueryService;
     private final SettlementQueryService settlementQueryService;
@@ -64,6 +69,14 @@ public class CenterControllerImpl implements CenterController{
     }
 
      */
+
+    @Override
+    public ResponseEntity<List<SearchCaregiverResponse>> searchCaregiver(
+            @RequestParam String keyword
+    ){
+        List<SearchCaregiverResponse> responses = caregiverQueryService.searchCaregiver(keyword);
+        return ResponseEntity.ok(responses);
+    }
 
     /**
      *
@@ -190,7 +203,7 @@ public class CenterControllerImpl implements CenterController{
      */
     @Override
     public ResponseEntity<GetDashboardPopularResponse> getDashboardPopular(@RequestParam UUID centerId){
-        GetDashboardPopularResponse response = caregiverQueryService.getCaregiverStatus(centerId);
+        GetDashboardPopularResponse response = caregiverQueryService.getCaregiverStats(centerId);
         return ResponseEntity.ok(response);
     }
 

--- a/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/controller/CenterControllerImpl.java
@@ -79,6 +79,7 @@ public class CenterControllerImpl implements CenterController{
         return ResponseEntity.ok(responses);
     }
 
+    // 요양보호사 소속 등록 API
     @Override
     public ResponseEntity<Void> registerCaregiver(@RequestBody CreateCaregiverCenterRequest request){
         Caregiver caregiver = caregiverQueryService.getCaregiver(request.caregiverId());

--- a/homecare/src/main/java/jaega/homecare/domain/center/dto/req/SearchCaregiverResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/dto/req/SearchCaregiverResponse.java
@@ -1,0 +1,11 @@
+package jaega.homecare.domain.center.dto.req;
+
+import java.util.UUID;
+
+public record SearchCaregiverResponse(
+        UUID caregiverId,
+        String name,
+        String phone,
+        String certificationNumber
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/center/entity/Center.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/entity/Center.java
@@ -23,10 +23,13 @@ public class Center {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @Column(name = "name")
     private String name;
 
+    @Column(name = "center_address")
     private String center_address;
 
+    @Column(name = "contact_number")
     private String contact_number;
 
     public void setCenter(UUID centerId, User user, String name, String center_address, String contact_number){

--- a/homecare/src/main/java/jaega/homecare/domain/center/service/command/CenterCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/center/service/command/CenterCommandService.java
@@ -8,6 +8,7 @@ import jaega.homecare.domain.center.dto.res.CenterLoginResponse;
 import jaega.homecare.domain.center.entity.Center;
 import jaega.homecare.domain.center.mapper.CenterMapper;
 import jaega.homecare.domain.center.service.query.CenterQueryService;
+import jaega.homecare.domain.users.dto.req.UserLoginRequest;
 import jaega.homecare.domain.users.entity.User;
 import jaega.homecare.domain.users.repository.UserRepository;
 import jaega.homecare.domain.users.service.command.UserCommandService;
@@ -25,9 +26,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class CenterCommandService {
 
-    private final UserRepository userRepository;
     private final CenterMapper centerMapper;
-    private final PasswordEncoder passwordEncoder;
     private final CenterQueryService centerQueryService;
     private final UserCommandService userCommandService;
     private final CaregiverCommandService caregiverCommandService;
@@ -77,11 +76,8 @@ public class CenterCommandService {
     }
 
     // 실제 로그인
-    public CenterLoginResponse loginCenter(CenterLoginRequest request){
-        User user = userRepository.findByEmail(request.email());
-        if (user == null || !passwordEncoder.matches(request.password(), user.getPassword())) {
-            throw new BadCredentialsException("로그인에 실패했습니다.");
-        }
+    public CenterLoginResponse loginCenter(UserLoginRequest request){
+        User user = userCommandService.loginUser(request);
         Center center = centerQueryService.findCenterByUser(user);
 
         return centerMapper.toLoginResponse(center);

--- a/homecare/src/main/java/jaega/homecare/domain/consumer/controller/ConsumerController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/consumer/controller/ConsumerController.java
@@ -27,6 +27,7 @@ import jaega.homecare.domain.serviceRequest.dto.res.GetCreateServiceResponse;
 import jaega.homecare.domain.serviceRequest.dto.res.GetServiceRequestById;
 import jaega.homecare.domain.serviceRequest.dto.res.GetServiceRequestResponse;
 import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
+import jaega.homecare.domain.users.dto.req.UserLoginRequest;
 import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageGuideResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -43,6 +44,11 @@ public interface ConsumerController {
     @ApiResponse(responseCode = "204", description = "수요자 회원가입 성공")
     @PostMapping("/register")
     ResponseEntity<Void> createConsumer(@RequestBody ConsumerSignupRequest request);
+
+    @Operation(summary = "수요자 로그인 API", description = "입력받은 정보로 수요자의 로그인을 진행합니다.")
+    @ApiResponse(responseCode = "200", description = "수요자 로그인 성공")
+    @PostMapping("/login")
+    ResponseEntity<ConsumerLoginResponse> loginConsumer(@RequestBody UserLoginRequest request);
 
     @Operation(summary = "(마이페이지) 수요자의 프로필 정보 조회 API", description = "수요자의 ID로 수요자의 프로필 정보를 조회합니다.")
     @ApiResponse(responseCode = "200", description = "수요자의 프로필 정보 조회 성공")

--- a/homecare/src/main/java/jaega/homecare/domain/consumer/controller/ConsumerControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/consumer/controller/ConsumerControllerImpl.java
@@ -39,6 +39,7 @@ import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
 import jaega.homecare.domain.serviceRequest.service.command.ServiceRequestCommandService;
 import jaega.homecare.domain.serviceRequest.service.query.ServiceRequestQueryService;
 import jaega.homecare.domain.consumer.service.command.ConsumerCommandService;
+import jaega.homecare.domain.users.dto.req.UserLoginRequest;
 import jaega.homecare.domain.voucher.service.query.VoucherQueryService;
 import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageGuideResponse;
 import jaega.homecare.domain.voucherUsage.service.query.VoucherUsageQueryService;
@@ -77,6 +78,13 @@ public class ConsumerControllerImpl implements ConsumerController {
     public ResponseEntity<Void> createConsumer(@RequestBody ConsumerSignupRequest request) {
         consumerCommandService.signupConsumer(request);
         return ResponseEntity.noContent().build();
+    }
+
+    // 수요자 로그인 API
+    @Override
+    public ResponseEntity<ConsumerLoginResponse> loginConsumer(@RequestBody UserLoginRequest request){
+        ConsumerLoginResponse response = consumerCommandService.loginConsumer(request);
+        return ResponseEntity.ok(response);
     }
 
     // (마이페이지) 수요자의 프로필 정보 조회 API

--- a/homecare/src/main/java/jaega/homecare/domain/consumer/dto/res/ConsumerLoginResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/consumer/dto/res/ConsumerLoginResponse.java
@@ -1,0 +1,8 @@
+package jaega.homecare.domain.consumer.dto.res;
+
+import java.util.UUID;
+
+public record ConsumerLoginResponse(
+        UUID consumerId
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/consumer/entity/Consumer.java
+++ b/homecare/src/main/java/jaega/homecare/domain/consumer/entity/Consumer.java
@@ -46,9 +46,11 @@ public class Consumer extends BaseTimeEntity {
     private Integer weight;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "disease")
     private Disease disease;                    // 질병 여부
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "cognitive_status")
     private CognitiveStatus cognitiveStatus;    // 인지 상태
 
     @Column(name ="livingSituation", columnDefinition = "TEXT")

--- a/homecare/src/main/java/jaega/homecare/domain/consumer/mapper/ConsumerMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/consumer/mapper/ConsumerMapper.java
@@ -2,6 +2,7 @@ package jaega.homecare.domain.consumer.mapper;
 
 import jaega.homecare.domain.consumer.dto.req.ConsumerCreateRequest;
 import jaega.homecare.domain.consumer.dto.res.ConsumerDetailResponse;
+import jaega.homecare.domain.consumer.dto.res.ConsumerLoginResponse;
 import jaega.homecare.domain.consumer.entity.Consumer;
 import jaega.homecare.domain.users.entity.User;
 import org.mapstruct.Mapper;
@@ -23,6 +24,8 @@ public interface ConsumerMapper {
     @Mapping(target = "guardianPhone", source = "request.guardianPhone")
     @Mapping(target = "consumerId", ignore = true)
     Consumer toConsumer(ConsumerCreateRequest request, User user);
+
+    ConsumerLoginResponse toLoginResponse(Consumer consumer);
 
     @Mapping(target = "name", source = "user.name")
     @Mapping(target = "birthDate", source = "user.birthDate")

--- a/homecare/src/main/java/jaega/homecare/domain/consumer/repository/ConsumerRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/consumer/repository/ConsumerRepository.java
@@ -1,6 +1,7 @@
 package jaega.homecare.domain.consumer.repository;
 
 import jaega.homecare.domain.consumer.entity.Consumer;
+import jaega.homecare.domain.users.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +9,6 @@ import java.util.UUID;
 
 public interface ConsumerRepository extends JpaRepository<Consumer, Long> {
     Optional<Consumer> findByConsumerId(UUID consumerId);
+
+    Consumer findByUser(User user);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/consumer/service/command/ConsumerCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/consumer/service/command/ConsumerCommandService.java
@@ -48,7 +48,7 @@ public class ConsumerCommandService {
     }
 
     public ConsumerLoginResponse loginConsumer(UserLoginRequest request){
-        User user = userQueryService.loginUser(request);
+        User user = userCommandService.loginUser(request);
         Consumer consumer = consumerRepository.findByUser(user);
         if(consumer == null) throw new BadCredentialsException("로그인에 실패했습니다.");
         return consumerMapper.toLoginResponse(consumer);

--- a/homecare/src/main/java/jaega/homecare/domain/consumer/service/command/ConsumerCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/consumer/service/command/ConsumerCommandService.java
@@ -3,14 +3,18 @@ package jaega.homecare.domain.consumer.service.command;
 import jaega.homecare.domain.consumer.dto.req.ConsumerCreateRequest;
 import jaega.homecare.domain.consumer.dto.req.ConsumerProfileUpdateRequest;
 import jaega.homecare.domain.consumer.dto.req.ConsumerSignupRequest;
+import jaega.homecare.domain.consumer.dto.res.ConsumerLoginResponse;
 import jaega.homecare.domain.consumer.entity.Consumer;
 import jaega.homecare.domain.consumer.mapper.ConsumerMapper;
 import jaega.homecare.domain.consumer.repository.ConsumerRepository;
+import jaega.homecare.domain.users.dto.req.UserLoginRequest;
 import jaega.homecare.domain.users.entity.User;
 import jaega.homecare.domain.users.entity.UserRole;
 import jaega.homecare.domain.users.service.command.UserCommandService;
+import jaega.homecare.domain.users.service.query.UserQueryService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
@@ -23,6 +27,7 @@ public class ConsumerCommandService {
     private final ConsumerRepository consumerRepository;
     private final ConsumerMapper consumerMapper;
     private final UserCommandService userCommandService;
+    private final UserQueryService userQueryService;
 
     public void signupConsumer(ConsumerSignupRequest request){
         User user = userCommandService.createUser(request.user(), UserRole.ROLE_CONSUMER);
@@ -40,5 +45,12 @@ public class ConsumerCommandService {
         consumer.updateConsumer(request.consumerRequest());
 
         consumerRepository.save(consumer);
+    }
+
+    public ConsumerLoginResponse loginConsumer(UserLoginRequest request){
+        User user = userQueryService.loginUser(request);
+        Consumer consumer = consumerRepository.findByUser(user);
+        if(consumer == null) throw new BadCredentialsException("로그인에 실패했습니다.");
+        return consumerMapper.toLoginResponse(consumer);
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/review/dto/res/CaregiverReviewDetailResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/review/dto/res/CaregiverReviewDetailResponse.java
@@ -1,0 +1,11 @@
+package jaega.homecare.domain.review.dto.res;
+
+import java.util.UUID;
+
+public record CaregiverReviewDetailResponse(
+        UUID reviewId,
+        String scheduleDetail,
+        Double reviewScore,
+        String reviewContent
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/review/dto/res/CaregiverReviewItem.java
+++ b/homecare/src/main/java/jaega/homecare/domain/review/dto/res/CaregiverReviewItem.java
@@ -1,0 +1,11 @@
+package jaega.homecare.domain.review.dto.res;
+
+import java.util.UUID;
+
+public record CaregiverReviewItem(
+        UUID reviewId,
+        String scheduleSummary,
+        Double reviewScore,
+        String reviewContent
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/review/dto/res/CaregiverReviewSummaryResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/review/dto/res/CaregiverReviewSummaryResponse.java
@@ -1,0 +1,9 @@
+package jaega.homecare.domain.review.dto.res;
+
+import java.util.List;
+
+public record CaregiverReviewSummaryResponse(
+        Double averageScore,
+        List<CaregiverReviewItem> reviews
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/review/mapper/ReviewMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/review/mapper/ReviewMapper.java
@@ -1,6 +1,8 @@
 package jaega.homecare.domain.review.mapper;
 
 import jaega.homecare.domain.review.dto.req.CreateReviewRequest;
+import jaega.homecare.domain.review.dto.res.CaregiverReviewDetailResponse;
+import jaega.homecare.domain.review.dto.res.CaregiverReviewItem;
 import jaega.homecare.domain.review.dto.res.ConsumerReviewResponse;
 import jaega.homecare.domain.review.dto.res.GetReviewResponse;
 import jaega.homecare.domain.review.entity.Review;
@@ -31,4 +33,12 @@ public interface ReviewMapper {
     ConsumerReviewResponse toConsumerReviewResponse(Review review);
 
     List<ConsumerReviewResponse> toConsumerReviewResponse(List<Review> reviews);
+
+    // TODO: ServiceMatch에서 일정 요약 가져오기
+    @Mapping(target = "scheduleSummary", ignore = true)
+    CaregiverReviewItem toCaregiverReviewItem(Review review);
+
+    // TODO: ServiceMatch에서 일정 상세 가져오기
+    @Mapping(target = "scheduleDetail", ignore = true)
+    CaregiverReviewDetailResponse toDetailResponse(Review review);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/review/repository/ReviewRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/review/repository/ReviewRepository.java
@@ -3,9 +3,14 @@ package jaega.homecare.domain.review.repository;
 import jaega.homecare.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     Optional<Review> findByServiceMatch_ServiceMatchId(UUID serviceMatchId);
+
+    List<Review> findByServiceMatch_Caregiver_CaregiverId(UUID caregiverId);
+
+    Optional<Review> findByReviewId(UUID reviewId);
 }

--- a/homecare/src/main/java/jaega/homecare/domain/review/service/query/ReviewQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/review/service/query/ReviewQueryService.java
@@ -1,7 +1,6 @@
 package jaega.homecare.domain.review.service.query;
 
-import jaega.homecare.domain.review.dto.res.ConsumerReviewResponse;
-import jaega.homecare.domain.review.dto.res.GetReviewResponse;
+import jaega.homecare.domain.review.dto.res.*;
 import jaega.homecare.domain.review.entity.Review;
 import jaega.homecare.domain.review.mapper.ReviewMapper;
 import jaega.homecare.domain.review.repository.ReviewQueryRepository;
@@ -31,5 +30,27 @@ public class ReviewQueryService {
     public List<ConsumerReviewResponse> getWrittenReviews(UUID consumerId) {
         List<Review> reviews = reviewQueryRepository.findWrittenReviewsByConsumer(consumerId);
         return reviewMapper.toConsumerReviewResponse(reviews);
+    }
+
+    public CaregiverReviewSummaryResponse getReviewsForCaregiver(UUID caregiverId) {
+        List<Review> reviews = reviewRepository.findByServiceMatch_Caregiver_CaregiverId(caregiverId);
+
+        double averageScore = reviews.stream()
+                .mapToDouble(Review::getReviewScore)
+                .average()
+                .orElse(0.0);
+
+        List<CaregiverReviewItem> reviewItems = reviews.stream()
+                .map(reviewMapper::toCaregiverReviewItem)
+                .toList();
+
+        return new CaregiverReviewSummaryResponse(averageScore, reviewItems);
+    }
+
+    public CaregiverReviewDetailResponse getReviewDetail(UUID reviewId) {
+        Review review = reviewRepository.findByReviewId(reviewId)
+                .orElseThrow(() -> new RuntimeException("리뷰를 찾을 수 없습니다."));
+
+        return reviewMapper.toDetailResponse(review);
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/entity/ServiceMatch.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/entity/ServiceMatch.java
@@ -39,10 +39,10 @@ public class ServiceMatch {
     @Column(name = "service_date")
     private LocalDate serviceDate;
 
-    @Column(name = "start_time")
+    @Column(name = "service_start_time")
     private LocalTime serviceStartTime;
 
-    @Column(name = "end_time")
+    @Column(name = "service_end_time")
     private LocalTime serviceEndTime;
 
     @Builder

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/entity/ServiceRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/entity/ServiceRequest.java
@@ -57,7 +57,7 @@ public class ServiceRequest {
     private ServiceType serviceType;        // 서비스 유형
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
+    @Column(name = "request_status", nullable = false)
     private ServiceRequestStatus requestStatus;    // 신청 상태
 
     @Column(name = "additional_information")

--- a/homecare/src/main/java/jaega/homecare/domain/users/entity/User.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/entity/User.java
@@ -18,22 +18,30 @@ public class User extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "user_id")
     private UUID userId;
 
+    @Column(name = "name")
     private String name;
 
+    @Column(name = "email")
     private String email;
 
+    @Column(name = "password")
     private String password;
 
+    @Column(name = "phone")
     private String phone;
 
+    @Column(name = "birthDate")
     private LocalDate birthDate;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "user_role")
     private UserRole userRole;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "gender")
     private Gender gender;
 
     @Builder

--- a/homecare/src/main/java/jaega/homecare/domain/users/service/command/UserCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/users/service/command/UserCommandService.java
@@ -8,7 +8,6 @@ import jaega.homecare.domain.users.entity.User;
 import jaega.homecare.domain.users.entity.UserRole;
 import jaega.homecare.domain.users.mapper.UserMapper;
 import jaega.homecare.domain.users.repository.UserRepository;
-import jaega.homecare.domain.users.service.query.UserQueryService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -53,4 +52,13 @@ public class UserCommandService {
         user.updateUser(request);
         userRepository.save(user);
     }
+
+    public User loginUser(UserLoginRequest request){
+        User user = userRepository.findByEmail(request.email());
+        if (user == null || !passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new BadCredentialsException("로그인에 실패했습니다.");
+        }
+        return user;
+    }
+
 }

--- a/homecare/src/main/java/jaega/homecare/domain/voucher/entity/Voucher.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucher/entity/Voucher.java
@@ -4,6 +4,7 @@ package jaega.homecare.domain.voucher.entity;
 import jaega.homecare.domain.consumer.entity.Consumer;
 import jaega.homecare.domain.users.entity.User;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -31,4 +32,12 @@ public class Voucher {
 
     @Column(name = "total_amount", nullable = false)
     private Long totalAmount;
+
+    @Builder
+    public Voucher(UUID voucherId, Consumer consumer, LocalDate voucherDate, Long totalAmount){
+        this.voucherId = voucherId;
+        this.consumer = consumer;
+        this.voucherDate = voucherDate;
+        this.totalAmount = totalAmount;
+    }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/voucher/repository/VoucherQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucher/repository/VoucherQueryRepository.java
@@ -22,6 +22,7 @@ public class VoucherQueryRepository {
 
         return queryFactory
                 .select(voucher.voucherId)
+                .from(voucher)
                 .where(
                         voucher.consumer.consumerId.eq(consumerId),
                         voucher.voucherDate.year().eq(LocalDate.now().getYear()),

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/query/VoucherUsageQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/query/VoucherUsageQueryService.java
@@ -23,6 +23,7 @@ public class VoucherUsageQueryService {
     // 바우처 사용 안내 조회
     public VoucherUsageGuideResponse getVoucherUsageGuide(UUID voucherId, Long totalVoucherAmount){
         Long usedAmount = voucherUsageQueryRepository.findTotalUsageAmountByVoucherId(voucherId, ServiceRequestStatus.ASSIGNED);
+        if(usedAmount == null) usedAmount = 0L;
         Long remainingAmount = totalVoucherAmount - usedAmount;
 
         Long expectedUsageAmount = (long) (DEFAULT_SERVICE_AMOUNT * (1 - MINIMUM_COPAY_RATE));   // 예상 바우처 사용액

--- a/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
+++ b/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
@@ -27,6 +27,8 @@ import jaega.homecare.domain.settlement.repository.SettlementRepository;
 import jaega.homecare.domain.settlement.service.command.SettlementCommandService;
 import jaega.homecare.domain.users.entity.*;
 import jaega.homecare.domain.users.repository.UserRepository;
+import jaega.homecare.domain.voucher.entity.Voucher;
+import jaega.homecare.domain.voucher.repository.VoucherRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -44,6 +46,7 @@ public class DummyDataService {
     private final CaregiverRepository caregiverRepository;
     private final ConsumerRepository consumerRepository;
     private final SettlementRepository settlementRepository;
+    private final VoucherRepository voucherRepository;
     private final CaregiverCenterRepository caregiverCenterRepository;
     private final ServiceRequestRepository serviceRequestRepository;
     private final CertificationRepository certificationRepository;
@@ -218,7 +221,7 @@ public class DummyDataService {
                 .residentialAddress("서울시 마포구 월드컵북로 " + index)
                 .visitAddress("서울시 강남구 봉은사로 " + index)
                 .entranceType("공동현관 비밀번호: " + (1000 + random.nextInt(9000)))
-                .careGrade(random.nextInt(5) + 1)
+                .careGrade(random.nextInt(6) + 1)
                 .isMedicalAid(random.nextBoolean())
                 .weight(40 + random.nextInt(40)) // 40~80kg
                 .disease(Disease.values()[random.nextInt(Disease.values().length)])
@@ -230,6 +233,18 @@ public class DummyDataService {
 
         consumer.initializeConsumer(UUID.randomUUID());
         consumerRepository.save(consumer);
+
+        // ✅ Consumer 생성 시 Voucher 생성
+        long totalAmount = getTotalAmountByCareGrade(consumer.getCareGrade());
+
+        Voucher voucher = Voucher.builder()
+                .voucherId(UUID.randomUUID())
+                .consumer(consumer)
+                .voucherDate(LocalDate.now()) // 이번 달 바우처
+                .totalAmount(totalAmount)
+                .build();
+
+        voucherRepository.save(voucher);
     }
 
     private void createDummyServiceRequest(int index) {
@@ -319,5 +334,16 @@ public class DummyDataService {
             );
             settlementCommandService.createSettlement(createSettlementRequest);
         }
+    }
+
+    private long getTotalAmountByCareGrade(int careGrade) {
+        return switch (careGrade) {
+            case 1 -> 1_520_700L;
+            case 2 -> 1_351_700L;
+            case 3 -> 1_295_400L;
+            case 4 -> 1_189_800L;
+            case 5 -> 1_021_300L;
+            default -> 573_900L; // 인지지원등급
+        };
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #46 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 1. 센터의 요양보호사 기관 등록 관련 API를 추가했습니다.
- 요양보호사 검색(이름, 전화번호)후 조회(이름, 전화번호, 자격증 번호) API
- 센터의 요양보호사 등록 API

### 2. 요양보호사의 마이페이지(리뷰) 관련 API를 추가했습니다.
- 요양보호사에게 등록된 리뷰들을 리스트로 조회하는 API
- 해당 리뷰 ID로 상세조회하는 API

### 3. 수요자, 요양보호사 로그인 API를 구현했습니다.
- 로그인 형식을 UserLogin으로 통합하고 센터, 수요자, 요양보호사의 로그인 API를 구현했습니다.

### 4. 더미 데이터 생성 시 수요자별 바우처를 추가하도록 했습니다.
- 수요자의 등급에 따라 바우처 금액이 추가되도록 했습니다.
 (1 ~ 6등급, 금액은 노션의 수요자 등급 참고)

### 5. 잘못된 속성의 '@Column' 이름을 제대로 매핑하도록 했습니다.

### 스크린샷 (선택)

<br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
