### PR TITLE
[#61] Consumer 바우처 내역 조회 추가 및 생성 Service 추가

### DIFF
--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/entity/Caregiver.java
@@ -61,4 +61,8 @@ public class Caregiver extends BaseTimeEntity {
     public void initializeCaregiver(UUID uuid) {
         this.caregiverId = uuid;
     }
+
+    public void changeVerifiedStatus(VerifiedStatus verifiedStatus){
+        this.verifiedStatus = verifiedStatus;
+    }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/consumer/controller/ConsumerController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/consumer/controller/ConsumerController.java
@@ -130,6 +130,11 @@ public interface ConsumerController {
     ResponseEntity<GetServiceRequestById> getServiceRequestById(@RequestParam UUID requestId);
 
 
+    @Operation(summary = "(메인 페이지) 거절된 수요자 매칭의 서비스 신청 취소 ", description = "수요자에게 거절된 일정의 신청 정보를 취소합니다.")
+    @ApiResponse(responseCode = "200", description = "수요자의 거절된 일정의 신청 정보 취소")
+    @PostMapping("/home/notification/reject")
+    ResponseEntity<Void> rejectServiceRequestByMatch(@RequestParam UUID serviceMatchId);
+
     /**
      *
      * 정기 제안 관련 API

--- a/homecare/src/main/java/jaega/homecare/domain/consumer/controller/ConsumerController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/consumer/controller/ConsumerController.java
@@ -15,10 +15,7 @@ import jaega.homecare.domain.recurringOffer.dto.res.GetRecurringOfferDetailRespo
 import jaega.homecare.domain.recurringOffer.dto.res.GetRecurringOfferResponse;
 import jaega.homecare.domain.recurringOffer.dto.res.GetUnreadRecurringOfferResponse;
 import jaega.homecare.domain.review.dto.req.CreateReviewRequest;
-import jaega.homecare.domain.serviceMatch.dto.res.ConsumerNextScheduleResponse;
-import jaega.homecare.domain.serviceMatch.dto.res.ConsumerScheduleDetailResponse;
-import jaega.homecare.domain.serviceMatch.dto.res.ConsumerScheduleResponse;
-import jaega.homecare.domain.serviceMatch.dto.res.GetScheduleWithoutReviewResponse;
+import jaega.homecare.domain.serviceMatch.dto.res.*;
 import jaega.homecare.domain.review.dto.res.ConsumerReviewResponse;
 import jaega.homecare.domain.review.dto.res.GetReviewResponse;
 import jaega.homecare.domain.serviceRequest.dto.req.ConsumerServiceRequest;
@@ -93,6 +90,12 @@ public interface ConsumerController {
     @GetMapping("/home/notification/review")
     ResponseEntity<List<GetScheduleWithoutReviewResponse>> getScheduleWithoutReview(@RequestParam UUID consumerId);
 
+
+    @Operation(summary = "(메인 페이지) 수요자에게 거절된 일정 조회", description = "수요자에게 거절된 일정들을 조회합니다.<br>" +
+            "이후 신청 취소 및 재매칭 유도에 이용됩니다.")
+    @ApiResponse(responseCode = "200", description = "수요자에게 거절된 일정 조회")
+    @GetMapping("/home/notification/reject")
+    ResponseEntity<List<ConsumerCancelledScheduleResponse>> getCancelledSchedule(@RequestParam UUID consumerId);
 
     /**
      *

--- a/homecare/src/main/java/jaega/homecare/domain/consumer/controller/ConsumerController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/consumer/controller/ConsumerController.java
@@ -29,6 +29,7 @@ import jaega.homecare.domain.serviceRequest.dto.res.GetServiceRequestResponse;
 import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
 import jaega.homecare.domain.users.dto.req.UserLoginRequest;
 import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageGuideResponse;
+import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -182,6 +183,16 @@ public interface ConsumerController {
     @ApiResponse(responseCode = "200", description = "바우처 사용 안내 조회 성공")
     @GetMapping("/request/voucher")
     ResponseEntity<VoucherUsageGuideResponse> getVoucherUsageGuide(@RequestParam UUID consumerId);
+
+    // (마이페이지) 재가 급여(바우처) 내역 조회
+    @Operation(summary = "(마이페이지) 재가 급여(바우처) 내역 조회", description = "마이페이지에서 수요자의 재가 급여(바우처) 내역을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "(마이페이지) 사용자의 재가 급여 내역 조회 성공")
+    @GetMapping("/my-page/voucher")
+    ResponseEntity<VoucherUsageResponse> getVoucherByConsumer(
+            @RequestParam UUID consumerId,
+            @RequestParam int year,
+            @RequestParam int month
+    );
 
     /**
      *

--- a/homecare/src/main/java/jaega/homecare/domain/consumer/controller/ConsumerControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/consumer/controller/ConsumerControllerImpl.java
@@ -18,10 +18,7 @@ import jaega.homecare.domain.recurringOffer.dto.res.GetUnreadRecurringOfferRespo
 import jaega.homecare.domain.recurringOffer.service.command.RecurringOfferCommandService;
 import jaega.homecare.domain.recurringOffer.service.query.RecurringOfferQueryService;
 import jaega.homecare.domain.review.dto.req.CreateReviewRequest;
-import jaega.homecare.domain.serviceMatch.dto.res.ConsumerNextScheduleResponse;
-import jaega.homecare.domain.serviceMatch.dto.res.ConsumerScheduleDetailResponse;
-import jaega.homecare.domain.serviceMatch.dto.res.ConsumerScheduleResponse;
-import jaega.homecare.domain.serviceMatch.dto.res.GetScheduleWithoutReviewResponse;
+import jaega.homecare.domain.serviceMatch.dto.res.*;
 import jaega.homecare.domain.review.dto.res.ConsumerReviewResponse;
 import jaega.homecare.domain.review.dto.res.GetReviewResponse;
 import jaega.homecare.domain.review.service.command.ReviewCommandService;
@@ -162,6 +159,13 @@ public class ConsumerControllerImpl implements ConsumerController {
     public ResponseEntity<List<GetScheduleWithoutReviewResponse>> getPendingReviews(@PathVariable UUID consumerId) {
         List<GetScheduleWithoutReviewResponse> pending = serviceMatchQueryService.getScheduleWithoutReview(consumerId);
         return ResponseEntity.ok(pending);
+    }
+
+    // (메인 페이지) 수요자에게 거절된 일정 조회
+    @Override
+    public ResponseEntity<List<ConsumerCancelledScheduleResponse>> getCancelledSchedule(@RequestParam UUID consumerId){
+        List<ConsumerCancelledScheduleResponse> responses = serviceMatchQueryService.getCancelledSchedules(consumerId);
+        return ResponseEntity.ok(responses);
     }
 
     /**

--- a/homecare/src/main/java/jaega/homecare/domain/consumer/controller/ConsumerControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/consumer/controller/ConsumerControllerImpl.java
@@ -204,9 +204,17 @@ public class ConsumerControllerImpl implements ConsumerController {
 
     // 수요자가 신청한 서비스 정보 상세 상세 조회
     @Override
-    public ResponseEntity<GetServiceRequestById> getServiceRequestById(UUID serviceRequestId) {
+    public ResponseEntity<GetServiceRequestById> getServiceRequestById(@RequestParam UUID serviceRequestId) {
         GetServiceRequestById response = serviceRequestQueryService.findServiceRequestById(serviceRequestId);
         return ResponseEntity.ok(response);
+    }
+
+
+    // (메인 페이지) 거절된 수요자 매칭의 서비스 신청 취소
+    @Override
+    public ResponseEntity<Void> rejectServiceRequestByMatch(@RequestParam UUID serviceMatchId){
+        serviceRequestCommandService.rejectServiceRequestByMatch(serviceMatchId);
+        return ResponseEntity.noContent().build();
     }
 
 

--- a/homecare/src/main/java/jaega/homecare/domain/consumer/controller/ConsumerControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/consumer/controller/ConsumerControllerImpl.java
@@ -42,6 +42,7 @@ import jaega.homecare.domain.consumer.service.command.ConsumerCommandService;
 import jaega.homecare.domain.users.dto.req.UserLoginRequest;
 import jaega.homecare.domain.voucher.service.query.VoucherQueryService;
 import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageGuideResponse;
+import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageResponse;
 import jaega.homecare.domain.voucherUsage.service.query.VoucherUsageQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -259,6 +260,17 @@ public class ConsumerControllerImpl implements ConsumerController {
 
         VoucherUsageGuideResponse response = voucherUsageQueryService.getVoucherUsageGuide(voucherId, totalVoucherAmount);
 
+        return ResponseEntity.ok(response);
+    }
+
+    // (마이페이지) 재가 급여(바우처) 내역 조회
+    @Override
+    public ResponseEntity<VoucherUsageResponse> getVoucherByConsumer(
+            @RequestParam UUID consumerId,
+            @RequestParam int year,
+            @RequestParam int month
+    ){
+        VoucherUsageResponse response = voucherUsageQueryService.getVoucherUsageSummary(consumerId, year, month);
         return ResponseEntity.ok(response);
     }
 

--- a/homecare/src/main/java/jaega/homecare/domain/consumer/service/command/ConsumerCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/consumer/service/command/ConsumerCommandService.java
@@ -12,6 +12,7 @@ import jaega.homecare.domain.users.entity.User;
 import jaega.homecare.domain.users.entity.UserRole;
 import jaega.homecare.domain.users.service.command.UserCommandService;
 import jaega.homecare.domain.users.service.query.UserQueryService;
+import jaega.homecare.domain.voucher.service.command.VoucherCommandService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -27,17 +28,21 @@ public class ConsumerCommandService {
     private final ConsumerRepository consumerRepository;
     private final ConsumerMapper consumerMapper;
     private final UserCommandService userCommandService;
-    private final UserQueryService userQueryService;
+    private final VoucherCommandService voucherCommandService;
 
     public void signupConsumer(ConsumerSignupRequest request){
         User user = userCommandService.createUser(request.user(), UserRole.ROLE_CONSUMER);
         createConsumer(request.consumer(), user);
+
     }
 
     public void createConsumer(ConsumerCreateRequest request, User user){
         Consumer consumer = consumerMapper.toConsumer(request, user);
         consumer.initializeConsumer(UUID.randomUUID());
         consumerRepository.save(consumer);
+
+        // 수요자의 현재 월의 바우처 생성
+        voucherCommandService.createVoucher(consumer.getConsumerId());
     }
 
     public void updateConsumer(ConsumerProfileUpdateRequest request, Consumer consumer){

--- a/homecare/src/main/java/jaega/homecare/domain/review/dto/req/CreateReviewRequest.java
+++ b/homecare/src/main/java/jaega/homecare/domain/review/dto/req/CreateReviewRequest.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 public record CreateReviewRequest(
         UUID consumerId,
         UUID serviceMatchId,
-        Integer reviewScore,
+        Double reviewScore,
         String reviewContent
 ) {
 }

--- a/homecare/src/main/java/jaega/homecare/domain/review/entity/Review.java
+++ b/homecare/src/main/java/jaega/homecare/domain/review/entity/Review.java
@@ -34,6 +34,7 @@ public class Review extends BaseTimeEntity {
     @Builder
     public Review(UUID reviewId, ServiceMatch serviceMatch, Double reviewScore,
                   String reviewContent) {
+        this.reviewId = reviewId;
         this.reviewContent = reviewContent;
         this.serviceMatch = serviceMatch;
         this.reviewScore = reviewScore;

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/dto/res/ConsumerCancelledScheduleResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/dto/res/ConsumerCancelledScheduleResponse.java
@@ -1,0 +1,13 @@
+package jaega.homecare.domain.serviceMatch.dto.res;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+public record ConsumerCancelledScheduleResponse(
+        UUID serviceMatchId,
+        LocalDate serviceDate,
+        LocalTime startTime,
+        LocalTime endTime,
+        String caregiverName
+) {}

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/entity/ServiceMatch.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/entity/ServiceMatch.java
@@ -58,4 +58,9 @@ public class ServiceMatch {
     public void initializeServiceMatch(UUID serviceMatchId){
         this.serviceMatchId = serviceMatchId;
     }
+
+    public void changeMatchStatus(MatchStatus matchStatus){
+        this.matchStatus = matchStatus;
+
+    }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/repository/ServiceMatchQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/repository/ServiceMatchQueryRepository.java
@@ -35,6 +35,9 @@ import java.time.LocalTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static jaega.homecare.domain.serviceMatch.entity.QServiceMatch.serviceMatch;
+import static jaega.homecare.domain.serviceRequest.entity.QServiceRequest.serviceRequest;
+
 @Repository
 @RequiredArgsConstructor
 public class ServiceMatchQueryRepository {
@@ -640,6 +643,24 @@ public class ServiceMatchQueryRepository {
                         serviceMatch.matchStatus.in(MatchStatus.CONFIRMED, MatchStatus.COMPLETED)
                 )
                 .orderBy(serviceMatch.serviceStartTime.asc())
+                .fetch();
+    }
+
+    public List<ConsumerCancelledScheduleResponse> getCancelledSchedules(UUID consumerId) {
+        return queryFactory
+                .select(Projections.constructor(
+                        ConsumerCancelledScheduleResponse.class,
+                        serviceMatch.serviceMatchId,
+                        serviceMatch.serviceDate,
+                        serviceMatch.serviceStartTime,
+                        serviceMatch.serviceEndTime,
+                        serviceMatch.caregiver.user.name
+                ))
+                .from(serviceMatch)
+                .join(serviceMatch.serviceRequest, serviceRequest)
+                .where(serviceRequest.consumer.consumerId.eq(consumerId)
+                        .and(serviceMatch.matchStatus.eq(MatchStatus.CANCELLED)))
+                .orderBy(serviceMatch.serviceDate.asc(), serviceMatch.serviceStartTime.asc())
                 .fetch();
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/repository/ServiceMatchQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/repository/ServiceMatchQueryRepository.java
@@ -663,4 +663,23 @@ public class ServiceMatchQueryRepository {
                 .orderBy(serviceMatch.serviceDate.asc(), serviceMatch.serviceStartTime.asc())
                 .fetch();
     }
+
+    /**
+     * 특정 요양보호사에 대해 주어진 날짜, 시간 범위에 중복된 매칭이 존재하는지 확인
+     */
+    public boolean existsByCaregiverAndDateTime(UUID caregiverId, LocalDate serviceDate, LocalTime startTime, LocalTime endTime) {
+        Long count = queryFactory
+                .select(serviceMatch.count())
+                .from(serviceMatch)
+                .where(
+                        serviceMatch.caregiver.caregiverId.eq(caregiverId),
+                        serviceMatch.serviceDate.eq(serviceDate),
+                        serviceMatch.matchStatus.in(MatchStatus.CONFIRMED, MatchStatus.COMPLETED),
+                        serviceMatch.serviceStartTime.lt(endTime)
+                                .and(serviceMatch.serviceEndTime.gt(startTime)) // 시간 겹침 체크
+                )
+                .fetchOne();
+
+        return count != null && count > 0;
+    }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/service/command/ServiceMatchCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/service/command/ServiceMatchCommandService.java
@@ -21,8 +21,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Transactional
 public class ServiceMatchCommandService {
-
-    private final ServiceMatchQueryService serviceMatchQueryService;
+    
     private final ServiceMatchRepository serviceMatchRepository;
     private final ServiceRequestQueryService serviceRequestQueryService;
     private final CaregiverQueryService caregiverQueryService;

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/service/command/ServiceMatchCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/service/command/ServiceMatchCommandService.java
@@ -3,10 +3,13 @@ package jaega.homecare.domain.serviceMatch.service.command;
 import jaega.homecare.domain.caregiver.entity.Caregiver;
 import jaega.homecare.domain.caregiver.service.query.CaregiverQueryService;
 import jaega.homecare.domain.serviceMatch.dto.req.CreateServiceMatchRequest;
+import jaega.homecare.domain.serviceMatch.entity.MatchStatus;
 import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
 import jaega.homecare.domain.serviceMatch.mapper.ServiceMatchMapper;
 import jaega.homecare.domain.serviceMatch.repository.ServiceMatchRepository;
+import jaega.homecare.domain.serviceMatch.service.query.ServiceMatchQueryService;
 import jaega.homecare.domain.serviceRequest.entity.ServiceRequest;
+import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
 import jaega.homecare.domain.serviceRequest.service.query.ServiceRequestQueryService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +22,7 @@ import java.util.UUID;
 @Transactional
 public class ServiceMatchCommandService {
 
+    private final ServiceMatchQueryService serviceMatchQueryService;
     private final ServiceMatchRepository serviceMatchRepository;
     private final ServiceRequestQueryService serviceRequestQueryService;
     private final CaregiverQueryService caregiverQueryService;

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/service/command/ServiceMatchCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/service/command/ServiceMatchCommandService.java
@@ -11,6 +11,9 @@ import jaega.homecare.domain.serviceMatch.service.query.ServiceMatchQueryService
 import jaega.homecare.domain.serviceRequest.entity.ServiceRequest;
 import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
 import jaega.homecare.domain.serviceRequest.service.query.ServiceRequestQueryService;
+import jaega.homecare.domain.voucher.entity.Voucher;
+import jaega.homecare.domain.voucher.service.query.VoucherQueryService;
+import jaega.homecare.domain.voucherUsage.service.command.VoucherUsageCommandService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,8 +24,10 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Transactional
 public class ServiceMatchCommandService {
-    
+
     private final ServiceMatchRepository serviceMatchRepository;
+    private final VoucherQueryService voucherQueryService;
+    private final VoucherUsageCommandService voucherUsageCommandService;
     private final ServiceRequestQueryService serviceRequestQueryService;
     private final CaregiverQueryService caregiverQueryService;
     private final ServiceMatchMapper serviceMatchMapper;
@@ -35,6 +40,11 @@ public class ServiceMatchCommandService {
         ServiceMatch serviceMatch = serviceMatchMapper.toEntity(request, serviceRequest, caregiver);
         serviceMatch.initializeServiceMatch(UUID.randomUUID());
         serviceMatchRepository.save(serviceMatch);
+
+        UUID voucherId = voucherQueryService.getVoucherIdByConsumerId(serviceRequest.getConsumer().getConsumerId());
+        Voucher voucher = voucherQueryService.getVoucher(voucherId);
+
+        voucherUsageCommandService.createVoucherUsage(voucher, serviceMatch);
 
         return serviceMatch.getServiceMatchId();
     }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/service/query/ServiceMatchQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/service/query/ServiceMatchQueryService.java
@@ -96,6 +96,10 @@ public class ServiceMatchQueryService {
         return serviceMatchQueryRepository.findCompletedScheduleWithoutReview(consumerId);
     }
 
+    public List<ConsumerCancelledScheduleResponse> getCancelledSchedules(UUID consumerId){
+        return serviceMatchQueryRepository.getCancelledSchedules(consumerId);
+    }
+
 
     /**
      *

--- a/homecare/src/main/java/jaega/homecare/domain/serviceRequest/service/command/ServiceRequestCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceRequest/service/command/ServiceRequestCommandService.java
@@ -2,10 +2,13 @@ package jaega.homecare.domain.serviceRequest.service.command;
 
 import jaega.homecare.domain.consumer.entity.Consumer;
 import jaega.homecare.domain.consumer.service.query.ConsumerQueryService;
+import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
+import jaega.homecare.domain.serviceMatch.service.query.ServiceMatchQueryService;
 import jaega.homecare.domain.serviceRequest.dto.req.ConsumerServiceRequest;
 import jaega.homecare.domain.serviceRequest.dto.req.UpdateServiceRequest;
 import jaega.homecare.domain.serviceRequest.dto.res.GetCreateServiceResponse;
 import jaega.homecare.domain.serviceRequest.entity.ServiceRequest;
+import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
 import jaega.homecare.domain.serviceRequest.mapper.ServiceRequestMapper;
 import jaega.homecare.domain.serviceRequest.repository.ServiceRequestRepository;
 import jakarta.transaction.Transactional;
@@ -22,6 +25,7 @@ public class ServiceRequestCommandService {
     private final ServiceRequestRepository serviceRequestRepository;
     private final ConsumerQueryService consumerQueryService;
     private final ServiceRequestMapper serviceRequestMapper;
+    private final ServiceMatchQueryService serviceMatchQueryService;
 
     public GetCreateServiceResponse createServiceRequest(ConsumerServiceRequest request){
         Consumer consumer = consumerQueryService.getConsumer(request.consumerId());
@@ -37,5 +41,11 @@ public class ServiceRequestCommandService {
     public void updateServiceRequest(UpdateServiceRequest request, ServiceRequest serviceRequest){
         serviceRequest.updateServiceRequest(request);
         serviceRequestRepository.save(serviceRequest);
+    }
+
+    public void rejectServiceRequestByMatch(UUID serviceMatchId){
+        ServiceMatch serviceMatch = serviceMatchQueryService.getServiceMatch(serviceMatchId);
+
+        serviceMatch.getServiceRequest().changeRequestStatus(ServiceRequestStatus.CANCELED);
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/voucher/entity/Voucher.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucher/entity/Voucher.java
@@ -40,4 +40,8 @@ public class Voucher {
         this.voucherDate = voucherDate;
         this.totalAmount = totalAmount;
     }
+
+    public void initializeVoucher(UUID voucherId){
+        this.voucherId = voucherId;
+    }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/voucher/mapper/VoucherMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucher/mapper/VoucherMapper.java
@@ -1,0 +1,19 @@
+package jaega.homecare.domain.voucher.mapper;
+
+import jaega.homecare.domain.consumer.entity.Consumer;
+import jaega.homecare.domain.voucher.entity.Voucher;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.time.LocalDate;
+
+@Mapper(componentModel = "spring")
+public interface VoucherMapper {
+
+    @Mapping(target = "consumer", source = "consumer")
+    @Mapping(target = "voucherDate", source = "voucherDate")
+    @Mapping(target = "totalAmount", source = "totalAmount")
+    @Mapping(target = "voucherId", ignore = true)
+    Voucher toEntity(Consumer consumer, LocalDate voucherDate, Long totalAmount);
+
+}

--- a/homecare/src/main/java/jaega/homecare/domain/voucher/repository/VoucherQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucher/repository/VoucherQueryRepository.java
@@ -35,6 +35,7 @@ public class VoucherQueryRepository {
                 .fetchOne();
     }
 
+    // 연도, 월별 바우처 조회
     public Voucher findByConsumerIdAndMonth(UUID consumerId, YearMonth targetMonth) {
         LocalDate startDate = targetMonth.atDay(1);
         LocalDate endDate = targetMonth.atEndOfMonth();

--- a/homecare/src/main/java/jaega/homecare/domain/voucher/repository/VoucherQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucher/repository/VoucherQueryRepository.java
@@ -2,11 +2,15 @@ package jaega.homecare.domain.voucher.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jaega.homecare.domain.voucher.entity.QVoucher;
+import jaega.homecare.domain.voucher.entity.Voucher;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.UUID;
+
+import static jaega.homecare.domain.voucher.entity.QVoucher.voucher;
 
 @Repository
 @RequiredArgsConstructor
@@ -29,5 +33,19 @@ public class VoucherQueryRepository {
                         voucher.voucherDate.month().eq(LocalDate.now().getMonthValue())
                 )
                 .fetchOne();
+    }
+
+    public Voucher findByConsumerIdAndMonth(UUID consumerId, YearMonth targetMonth) {
+        LocalDate startDate = targetMonth.atDay(1);
+        LocalDate endDate = targetMonth.atEndOfMonth();
+
+        return queryFactory
+                .selectFrom(voucher)
+                .where(
+                        voucher.consumer.consumerId.eq(consumerId), // Consumer ID 기준
+                        voucher.voucherDate.between(startDate, endDate) // 월 기준
+                )
+                .fetchOne();
+
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/voucher/service/command/VoucherCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucher/service/command/VoucherCommandService.java
@@ -1,0 +1,42 @@
+package jaega.homecare.domain.voucher.service.command;
+
+import jaega.homecare.domain.consumer.entity.Consumer;
+import jaega.homecare.domain.consumer.service.query.ConsumerQueryService;
+import jaega.homecare.domain.voucher.entity.Voucher;
+import jaega.homecare.domain.voucher.mapper.VoucherMapper;
+import jaega.homecare.domain.voucher.repository.VoucherRepository;
+import jaega.homecare.domain.voucher.service.query.VoucherQueryService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class VoucherCommandService {
+    private final VoucherRepository voucherRepository;
+    private final ConsumerQueryService consumerQueryService;
+    private final VoucherMapper voucherMapper;
+
+    public void createVoucher(UUID consumerId){
+        Consumer consumer = consumerQueryService.getConsumer(consumerId);
+        Long totalAmount = getTotalAmountByCareGrade(consumer.getCareGrade());
+        Voucher voucher = voucherMapper.toEntity(consumer, LocalDate.now(), totalAmount);
+        voucher.initializeVoucher(UUID.randomUUID());
+        voucherRepository.save(voucher);
+    }
+
+    public long getTotalAmountByCareGrade(int careGrade) {
+        return switch (careGrade) {
+            case 1 -> 1_520_700L;
+            case 2 -> 1_351_700L;
+            case 3 -> 1_295_400L;
+            case 4 -> 1_189_800L;
+            case 5 -> 1_021_300L;
+            default -> 573_900L; // 인지지원등급
+        };
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/voucher/service/query/VoucherQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucher/service/query/VoucherQueryService.java
@@ -1,5 +1,6 @@
 package jaega.homecare.domain.voucher.service.query;
 
+import jaega.homecare.domain.voucher.entity.Voucher;
 import jaega.homecare.domain.voucher.repository.VoucherQueryRepository;
 import jaega.homecare.domain.voucher.repository.VoucherRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,12 @@ public class VoucherQueryService {
 
     private final VoucherRepository voucherRepository;
     private final VoucherQueryRepository voucherQueryRepository;
+
+    // 바우처 도메인 조회
+    public Voucher getVoucher(UUID voucherId){
+        return voucherRepository.findByVoucherId(voucherId)
+                .orElseThrow(() -> new NoSuchElementException("해당 바우처 ID로 바우처를 찾을 수 없습니다."));
+    }
 
     public Long getTotalAmount(UUID voucherId) {
         return voucherRepository.findByVoucherId(voucherId)

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/dto/res/VoucherUsageCost.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/dto/res/VoucherUsageCost.java
@@ -1,0 +1,9 @@
+package jaega.homecare.domain.voucherUsage.dto.res;
+
+public record VoucherUsageCost(
+        long usedAmount,
+        long expectedAmount,
+        long confirmedCopay,
+        long totalCopay
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/dto/res/VoucherUsageCost.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/dto/res/VoucherUsageCost.java
@@ -2,8 +2,8 @@ package jaega.homecare.domain.voucherUsage.dto.res;
 
 public record VoucherUsageCost(
         long usedAmount,
+        long usedCopay,
         long expectedAmount,
-        long confirmedCopay,
-        long totalCopay
+        long confirmedCopay
 ) {
 }

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/dto/res/VoucherUsageDetail.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/dto/res/VoucherUsageDetail.java
@@ -1,0 +1,14 @@
+package jaega.homecare.domain.voucherUsage.dto.res;
+
+import jaega.homecare.domain.serviceMatch.entity.MatchStatus;
+
+import java.time.LocalDate;
+
+public record VoucherUsageDetail(
+        LocalDate serviceDate,
+        Long amount,
+        Long copay,
+        String serviceType,
+        MatchStatus matchStatus
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/dto/res/VoucherUsageResponse.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/dto/res/VoucherUsageResponse.java
@@ -1,0 +1,14 @@
+package jaega.homecare.domain.voucherUsage.dto.res;
+
+import java.util.List;
+
+public record VoucherUsageResponse(
+        Long totalAmount,
+        Long usedAmount,
+        Long expectedAmount,
+        Long remainingAmount,
+        Long confirmedCopay,
+        Long totalCopay,
+        List<VoucherUsageDetail> usageList
+) {
+}

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/entity/ServiceFee.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/entity/ServiceFee.java
@@ -1,0 +1,3 @@
+package jaega.homecare.domain.voucherUsage.entity;
+
+public record ServiceFee(Long totalAmount, Long copay) {}

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/entity/VoucherUsage.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/entity/VoucherUsage.java
@@ -4,6 +4,7 @@ import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
 import jaega.homecare.domain.voucher.entity.Voucher;
 import jaega.homecare.global.audit.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,4 +36,16 @@ public class VoucherUsage extends BaseTimeEntity {
     @Column(name = "copay", nullable = false)
     private Long copay;                         // 본인 부담금
 
+    @Builder
+    public VoucherUsage(UUID voucherUsageId, Voucher voucher, ServiceMatch serviceMatch, Long amount, Long copay){
+        this.voucherUsageId = voucherUsageId;
+        this.voucher = voucher;
+        this.serviceMatch = serviceMatch;
+        this.amount = amount;
+        this.copay = copay;
+    }
+
+    public void initializeVoucherUsage(UUID voucherUsageId){
+        this.voucherUsageId = voucherUsageId;
+    }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/mapper/VoucherUsageMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/mapper/VoucherUsageMapper.java
@@ -1,12 +1,23 @@
 package jaega.homecare.domain.voucherUsage.mapper;
 
+import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
+import jaega.homecare.domain.voucher.entity.Voucher;
 import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageGuideResponse;
+import jaega.homecare.domain.voucherUsage.entity.VoucherUsage;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 
 @Mapper(componentModel = "spring")
 public interface VoucherUsageMapper {
+
+
+    @Mapping(target = "voucher", source = "voucher")
+    @Mapping(target = "serviceMatch", source = "serviceMatch")
+    @Mapping(target = "amount", source = "amount")
+    @Mapping(target = "copay", source = "copay")
+    @Mapping(target = "voucherUsageId", ignore = true)
+    VoucherUsage toEntity(Voucher voucher, ServiceMatch serviceMatch, long amount, long copay);
 
     @Mapping(target = "isHighCopayRate",
             expression = "java(isHighCopayRate(remainingAmount, expectedUsageAmount))")

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/mapper/VoucherUsageMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/mapper/VoucherUsageMapper.java
@@ -36,9 +36,9 @@ public interface VoucherUsageMapper {
     @Mapping(target = "expectedAmount", source = "cost.expectedAmount")
     @Mapping(target = "remainingAmount", source = "remainingAmount")
     @Mapping(target = "confirmedCopay", source = "cost.confirmedCopay")
-    @Mapping(target = "totalCopay", source = "cost.totalCopay")
+    @Mapping(target = "totalCopay", source = "totalCopay")
     @Mapping(target = "usageList", source = "usageList")
-    VoucherUsageResponse toVoucherUsageResponse(Voucher voucher, VoucherUsageCost cost, long remainingAmount, List<VoucherUsageDetail> usageList);
+    VoucherUsageResponse toVoucherUsageResponse(Voucher voucher, VoucherUsageCost cost, long remainingAmount, long totalCopay, List<VoucherUsageDetail> usageList);
 
     @Mapping(target = "isHighCopayRate",
             expression = "java(isHighCopayRate(remainingAmount, expectedUsageAmount))")

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/mapper/VoucherUsageMapper.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/mapper/VoucherUsageMapper.java
@@ -2,11 +2,16 @@ package jaega.homecare.domain.voucherUsage.mapper;
 
 import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
 import jaega.homecare.domain.voucher.entity.Voucher;
+import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageCost;
+import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageDetail;
 import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageGuideResponse;
+import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageResponse;
 import jaega.homecare.domain.voucherUsage.entity.VoucherUsage;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
+
+import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface VoucherUsageMapper {
@@ -18,6 +23,22 @@ public interface VoucherUsageMapper {
     @Mapping(target = "copay", source = "copay")
     @Mapping(target = "voucherUsageId", ignore = true)
     VoucherUsage toEntity(Voucher voucher, ServiceMatch serviceMatch, long amount, long copay);
+
+    @Mapping(source = "serviceMatch.serviceDate", target = "serviceDate")
+    @Mapping(source = "amount", target = "amount")
+    @Mapping(source = "copay", target = "copay")
+    @Mapping(source = "serviceMatch.serviceRequest.serviceType", target = "serviceType")
+    @Mapping(source = "serviceMatch.matchStatus", target = "matchStatus")
+    VoucherUsageDetail toVoucherUsageDetail(VoucherUsage usage);
+
+    @Mapping(target = "totalAmount", source = "voucher.totalAmount")
+    @Mapping(target = "usedAmount", source = "cost.usedAmount")
+    @Mapping(target = "expectedAmount", source = "cost.expectedAmount")
+    @Mapping(target = "remainingAmount", source = "remainingAmount")
+    @Mapping(target = "confirmedCopay", source = "cost.confirmedCopay")
+    @Mapping(target = "totalCopay", source = "cost.totalCopay")
+    @Mapping(target = "usageList", source = "usageList")
+    VoucherUsageResponse toVoucherUsageResponse(Voucher voucher, VoucherUsageCost cost, long remainingAmount, List<VoucherUsageDetail> usageList);
 
     @Mapping(target = "isHighCopayRate",
             expression = "java(isHighCopayRate(remainingAmount, expectedUsageAmount))")

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/repository/VoucherUsageQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/repository/VoucherUsageQueryRepository.java
@@ -7,11 +7,17 @@ import jaega.homecare.domain.serviceMatch.entity.QServiceMatch;
 import jaega.homecare.domain.serviceRequest.entity.QServiceRequest;
 import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
 import jaega.homecare.domain.voucher.entity.QVoucher;
+import jaega.homecare.domain.voucher.entity.Voucher;
 import jaega.homecare.domain.voucherUsage.entity.QVoucherUsage;
+import jaega.homecare.domain.voucherUsage.entity.VoucherUsage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
+
+import static jaega.homecare.domain.voucher.entity.QVoucher.voucher;
+import static jaega.homecare.domain.voucherUsage.entity.QVoucherUsage.voucherUsage;
 
 @Repository
 @RequiredArgsConstructor
@@ -32,5 +38,16 @@ public class VoucherUsageQueryRepository {
                 .fetchOne();
     }
 
+    public List<VoucherUsage> findByVoucherAndStatus(Voucher voucher, MatchStatus status) {
+        return queryFactory
+                .selectFrom(voucherUsage)
+                .join(voucherUsage.serviceMatch)
+                .fetchJoin()
+                .where(
+                        voucherUsage.voucher.eq(voucher),
+                        voucherUsage.serviceMatch.matchStatus.eq(status)
+                )
+                .fetch();
+    }
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/repository/VoucherUsageQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/repository/VoucherUsageQueryRepository.java
@@ -65,10 +65,10 @@ public class VoucherUsageQueryRepository {
                 .groupBy(sm.matchStatus)
                 .fetch();
 
-        long usedAmount = 0L;
-        long expectedAmount = 0L;
-        long confirmedCopay = 0L;
-        long totalCopay = 0L;
+        long usedAmount = 0L;       // 현재까지의 총 사용금액
+        long usedCopay = 0L;       // 현재까지의 본인 부담금
+        long expectedAmount = 0L;   // 예상 금액 ( 매칭 완료 전 )
+        long confirmedCopay = 0L;   // 예상 본인부담금 ( 매칭 완료 전 )
 
         for (Tuple t : sums) {
             MatchStatus status = t.get(sm.matchStatus);
@@ -78,17 +78,17 @@ public class VoucherUsageQueryRepository {
             if (amountSum == null) amountSum = 0L;
             if (copaySum == null) copaySum = 0L;
 
-            totalCopay += copaySum;
 
             if (status == MatchStatus.COMPLETED) {
                 usedAmount = amountSum;
-                confirmedCopay = copaySum;
+                usedCopay = copaySum;
             } else if (status == MatchStatus.CONFIRMED) {
                 expectedAmount = amountSum;
+                confirmedCopay = copaySum;
             }
         }
 
-        return new VoucherUsageCost(usedAmount, expectedAmount, confirmedCopay, totalCopay);
+        return new VoucherUsageCost(usedAmount, expectedAmount, confirmedCopay, usedCopay);
     }
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/repository/VoucherUsageQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/repository/VoucherUsageQueryRepository.java
@@ -1,12 +1,9 @@
 package jaega.homecare.domain.voucherUsage.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import jaega.homecare.domain.consumer.entity.QConsumer;
 import jaega.homecare.domain.serviceMatch.entity.MatchStatus;
-import jaega.homecare.domain.serviceMatch.entity.QServiceMatch;
 import jaega.homecare.domain.serviceRequest.entity.QServiceRequest;
 import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
-import jaega.homecare.domain.voucher.entity.QVoucher;
 import jaega.homecare.domain.voucher.entity.Voucher;
 import jaega.homecare.domain.voucherUsage.entity.QVoucherUsage;
 import jaega.homecare.domain.voucherUsage.entity.VoucherUsage;
@@ -16,7 +13,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.UUID;
 
-import static jaega.homecare.domain.voucher.entity.QVoucher.voucher;
 import static jaega.homecare.domain.voucherUsage.entity.QVoucherUsage.voucherUsage;
 
 @Repository
@@ -38,14 +34,15 @@ public class VoucherUsageQueryRepository {
                 .fetchOne();
     }
 
-    public List<VoucherUsage> findByVoucherAndStatus(Voucher voucher, MatchStatus status) {
+    // 매칭 상태 별 바우처 내역 조회
+    public List<VoucherUsage> findByVoucherAndStatusIn(Voucher voucher, List<MatchStatus> statuses) {
         return queryFactory
                 .selectFrom(voucherUsage)
                 .join(voucherUsage.serviceMatch)
                 .fetchJoin()
                 .where(
                         voucherUsage.voucher.eq(voucher),
-                        voucherUsage.serviceMatch.matchStatus.eq(status)
+                        voucherUsage.serviceMatch.matchStatus.in(statuses)
                 )
                 .fetch();
     }

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/repository/VoucherUsageQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/repository/VoucherUsageQueryRepository.java
@@ -1,10 +1,14 @@
 package jaega.homecare.domain.voucherUsage.repository;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jaega.homecare.domain.serviceMatch.entity.MatchStatus;
+import jaega.homecare.domain.serviceMatch.entity.QServiceMatch;
 import jaega.homecare.domain.serviceRequest.entity.QServiceRequest;
 import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
 import jaega.homecare.domain.voucher.entity.Voucher;
+import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageCost;
+import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageResponse;
 import jaega.homecare.domain.voucherUsage.entity.QVoucherUsage;
 import jaega.homecare.domain.voucherUsage.entity.VoucherUsage;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +49,46 @@ public class VoucherUsageQueryRepository {
                         voucherUsage.serviceMatch.matchStatus.in(statuses)
                 )
                 .fetch();
+    }
+
+
+    public VoucherUsageCost findVoucherUsageSummary(Voucher voucher) {
+        QVoucherUsage vu = QVoucherUsage.voucherUsage;
+        QServiceMatch sm = QServiceMatch.serviceMatch;
+
+        // 상태별 금액 합계 조회
+        List<Tuple> sums = queryFactory
+                .select(sm.matchStatus, vu.amount.sum(), vu.copay.sum())
+                .from(vu)
+                .join(vu.serviceMatch, sm)
+                .where(vu.voucher.eq(voucher))
+                .groupBy(sm.matchStatus)
+                .fetch();
+
+        long usedAmount = 0L;
+        long expectedAmount = 0L;
+        long confirmedCopay = 0L;
+        long totalCopay = 0L;
+
+        for (Tuple t : sums) {
+            MatchStatus status = t.get(sm.matchStatus);
+            Long amountSum = t.get(vu.amount.sum());
+            Long copaySum = t.get(vu.copay.sum());
+
+            if (amountSum == null) amountSum = 0L;
+            if (copaySum == null) copaySum = 0L;
+
+            totalCopay += copaySum;
+
+            if (status == MatchStatus.COMPLETED) {
+                usedAmount = amountSum;
+                confirmedCopay = copaySum;
+            } else if (status == MatchStatus.CONFIRMED) {
+                expectedAmount = amountSum;
+            }
+        }
+
+        return new VoucherUsageCost(usedAmount, expectedAmount, confirmedCopay, totalCopay);
     }
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/command/ServiceFeeTable.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/command/ServiceFeeTable.java
@@ -1,0 +1,22 @@
+package jaega.homecare.domain.voucherUsage.service.command;
+
+import jaega.homecare.domain.voucherUsage.entity.ServiceFee;
+
+import java.util.Map;
+
+public class ServiceFeeTable {
+    private static final Map<Integer, ServiceFee> feeTable = Map.of(
+            30, new ServiceFee(16940L, 2541L),
+            60, new ServiceFee(24580L, 3687L),
+            90, new ServiceFee(33120L, 4968L),
+            120, new ServiceFee(42160L, 6324L),
+            150, new ServiceFee(49160L, 7374L),
+            180, new ServiceFee(55350L, 8303L),
+            210, new ServiceFee(61670L, 9251L),
+            240, new ServiceFee(68030L, 10205L)
+    );
+
+    public static ServiceFee getFee(int minutes) {
+        return feeTable.getOrDefault(minutes, feeTable.get(180)); // 기본값: 180분
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/command/ServiceFeeTable.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/command/ServiceFeeTable.java
@@ -4,6 +4,8 @@ import jaega.homecare.domain.voucherUsage.entity.ServiceFee;
 
 import java.util.Map;
 
+// TODO : 현재 방문 요양 기준으로만 금액 계산
+// 서비스 유형 별 금액 계산
 public class ServiceFeeTable {
     private static final Map<Integer, ServiceFee> feeTable = Map.of(
             30, new ServiceFee(16940L, 2541L),

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/command/VoucherUsageCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/command/VoucherUsageCommandService.java
@@ -1,0 +1,36 @@
+package jaega.homecare.domain.voucherUsage.service.command;
+
+import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
+import jaega.homecare.domain.voucher.entity.Voucher;
+import jaega.homecare.domain.voucherUsage.entity.ServiceFee;
+import jaega.homecare.domain.voucherUsage.entity.VoucherUsage;
+import jaega.homecare.domain.voucherUsage.mapper.VoucherUsageMapper;
+import jaega.homecare.domain.voucherUsage.repository.VoucherUsageRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class VoucherUsageCommandService {
+    private final VoucherUsageRepository voucherUsageRepository;
+    private final VoucherUsageMapper voucherUsageMapper;
+
+    // 방문 요양 기준으로만 금액 책정
+    public void createVoucherUsage(Voucher voucher, ServiceMatch serviceMatch){
+        int durationMinutes = (int) Duration.between(
+                serviceMatch.getServiceStartTime(),
+                serviceMatch.getServiceEndTime()
+        ).toMinutes();
+
+        ServiceFee fee = ServiceFeeTable.getFee(durationMinutes);
+
+        VoucherUsage voucherUsage = voucherUsageMapper.toEntity(voucher, serviceMatch, fee.totalAmount(), fee.copay());
+        voucherUsage.initializeVoucherUsage(UUID.randomUUID());
+        voucherUsageRepository.save(voucherUsage);
+    }
+}

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/query/VoucherUsageQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/query/VoucherUsageQueryService.java
@@ -1,14 +1,23 @@
 package jaega.homecare.domain.voucherUsage.service.query;
 
+import jaega.homecare.domain.serviceMatch.entity.MatchStatus;
 import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
+import jaega.homecare.domain.voucher.entity.Voucher;
+import jaega.homecare.domain.voucher.repository.VoucherQueryRepository;
+import jaega.homecare.domain.voucher.repository.VoucherRepository;
+import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageDetail;
 import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageGuideResponse;
+import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageResponse;
+import jaega.homecare.domain.voucherUsage.entity.VoucherUsage;
 import jaega.homecare.domain.voucherUsage.mapper.VoucherUsageMapper;
 import jaega.homecare.domain.voucherUsage.repository.VoucherUsageQueryRepository;
+import jaega.homecare.domain.voucherUsage.repository.VoucherUsageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.UUID;
+import java.time.YearMonth;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +26,8 @@ public class VoucherUsageQueryService {
     private static final double MINIMUM_COPAY_RATE = 0.15;      // 법정 부담률 15%
     private static final long DEFAULT_SERVICE_AMOUNT = 55350L;  // (하드코딩) 재가요양 3시간 기준 금액으로 고정
 
+    private final VoucherQueryRepository voucherQueryRepository;
+    private final VoucherUsageRepository voucherUsageRepository;
     private final VoucherUsageQueryRepository voucherUsageQueryRepository;
     private final VoucherUsageMapper voucherUsageMapper;
 
@@ -38,6 +49,51 @@ public class VoucherUsageQueryService {
         Long exceededAmount = Math.max(0L, expectedUsageAmount - remainingAmount);      // 초과 금액 계산
 
         return baseCopay + exceededAmount;
+    }
+
+    public VoucherUsageResponse getVoucherUsageSummary(UUID consumerId, int year, int month){
+        YearMonth targetMonth = YearMonth.of(year, month);
+        Voucher voucher = voucherQueryRepository.findByConsumerIdAndMonth(consumerId, targetMonth);
+
+        List<VoucherUsage> completedUsage = voucherUsageQueryRepository.findByVoucherAndStatus(voucher, MatchStatus.COMPLETED);
+        List<VoucherUsage> confirmedUsage = voucherUsageQueryRepository.findByVoucherAndStatus(voucher, MatchStatus.CONFIRMED);
+
+        long usedAmount = completedUsage.stream().mapToLong(VoucherUsage::getAmount).sum();
+        long expectedAmount = confirmedUsage.stream().mapToLong(VoucherUsage::getAmount).sum();
+        long remainingAmount = voucher.getTotalAmount() - (usedAmount + expectedAmount);
+
+        long confirmedCopay = completedUsage.stream().mapToLong(VoucherUsage::getCopay).sum();
+        long totalCopay = confirmedCopay + confirmedUsage.stream().mapToLong(VoucherUsage::getCopay).sum();
+
+
+        // 두 리스트 합치기
+        List<VoucherUsage> allUsage = new ArrayList<>();
+        allUsage.addAll(completedUsage);
+        allUsage.addAll(confirmedUsage);
+
+        // 날짜 기준 정렬 (최신순)
+        allUsage.sort(Comparator.comparing(u -> u.getServiceMatch().getServiceRequest().getRequestDate(), Comparator.reverseOrder()));
+
+        // 응답 DTO 변환
+        List<VoucherUsageDetail> usageList = allUsage.stream()
+                .map(u -> new VoucherUsageDetail(
+                        u.getServiceMatch().getServiceRequest().getRequestDate(),
+                        u.getAmount(),
+                        u.getCopay(),
+                        u.getServiceMatch().getServiceRequest().getServiceType().name(),
+                        u.getServiceMatch().getMatchStatus()
+                ))
+                .toList();
+
+        return new VoucherUsageResponse(
+                voucher.getTotalAmount(),
+                usedAmount,
+                expectedAmount,
+                remainingAmount,
+                confirmedCopay,
+                totalCopay,
+                usageList
+        );
     }
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/query/VoucherUsageQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/query/VoucherUsageQueryService.java
@@ -57,6 +57,10 @@ public class VoucherUsageQueryService {
         YearMonth targetMonth = YearMonth.of(year, month);
         Voucher voucher = voucherQueryRepository.findByConsumerIdAndMonth(consumerId, targetMonth);
 
+        if (voucher == null) {
+            throw new IllegalArgumentException("해당 월에 바우처가 없습니다.");
+        }
+
         // 금액 합계 조회
         VoucherUsageCost cost = voucherUsageQueryRepository.findVoucherUsageSummary(voucher);
 

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/query/VoucherUsageQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/query/VoucherUsageQueryService.java
@@ -5,6 +5,7 @@ import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
 import jaega.homecare.domain.voucher.entity.Voucher;
 import jaega.homecare.domain.voucher.repository.VoucherQueryRepository;
 import jaega.homecare.domain.voucher.repository.VoucherRepository;
+import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageCost;
 import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageDetail;
 import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageGuideResponse;
 import jaega.homecare.domain.voucherUsage.dto.res.VoucherUsageResponse;
@@ -52,57 +53,27 @@ public class VoucherUsageQueryService {
     }
 
     // 바우처 상세 내역 조회
-    public VoucherUsageResponse getVoucherUsageSummary(UUID consumerId, int year, int month){
+    public VoucherUsageResponse getVoucherUsageSummary(UUID consumerId, int year, int month) {
         YearMonth targetMonth = YearMonth.of(year, month);
         Voucher voucher = voucherQueryRepository.findByConsumerIdAndMonth(consumerId, targetMonth);
 
-        // 두 상태를 한 번에 조회
+        // 금액 합계 조회
+        VoucherUsageCost cost = voucherUsageQueryRepository.findVoucherUsageSummary(voucher);
+
+        // 상태별 사용 내역 조회 (정렬 포함)
         List<VoucherUsage> allUsage = voucherUsageQueryRepository.findByVoucherAndStatusIn(
                 voucher, List.of(MatchStatus.COMPLETED, MatchStatus.CONFIRMED)
         );
 
-        // 금액 계산
-        long usedAmount = allUsage.stream()
-                .filter(u -> u.getServiceMatch().getMatchStatus() == MatchStatus.COMPLETED)
-                .mapToLong(VoucherUsage::getAmount)
-                .sum();
-
-        long expectedAmount = allUsage.stream()
-                .filter(u -> u.getServiceMatch().getMatchStatus() == MatchStatus.CONFIRMED)
-                .mapToLong(VoucherUsage::getAmount)
-                .sum();
-
-        long remainingAmount = voucher.getTotalAmount() - (usedAmount + expectedAmount);
-
-        long totalCopay = allUsage.stream().mapToLong(VoucherUsage::getCopay).sum();
-        long confirmedCopay = allUsage.stream()
-                .filter(u -> u.getServiceMatch().getMatchStatus() == MatchStatus.COMPLETED)
-                .mapToLong(VoucherUsage::getCopay)
-                .sum();
-
-        // 날짜 기준 정렬 (최신순)
         allUsage.sort(Comparator.comparing(u -> u.getServiceMatch().getServiceRequest().getRequestDate(), Comparator.reverseOrder()));
 
-        // 응답 DTO 변환
         List<VoucherUsageDetail> usageList = allUsage.stream()
-                .map(u -> new VoucherUsageDetail(
-                        u.getServiceMatch().getServiceRequest().getRequestDate(),
-                        u.getAmount(),
-                        u.getCopay(),
-                        u.getServiceMatch().getServiceRequest().getServiceType().name(),
-                        u.getServiceMatch().getMatchStatus()
-                ))
+                .map(voucherUsageMapper::toVoucherUsageDetail)
                 .toList();
 
-        return new VoucherUsageResponse(
-                voucher.getTotalAmount(),
-                usedAmount,
-                expectedAmount,
-                remainingAmount,
-                confirmedCopay,
-                totalCopay,
-                usageList
-        );
+        long remainingAmount = voucher.getTotalAmount() - (cost.usedAmount() + cost.expectedAmount());
+
+        return voucherUsageMapper.toVoucherUsageResponse(voucher, cost, remainingAmount, usageList);
     }
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/query/VoucherUsageQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/query/VoucherUsageQueryService.java
@@ -51,25 +51,34 @@ public class VoucherUsageQueryService {
         return baseCopay + exceededAmount;
     }
 
+    // 바우처 상세 내역 조회
     public VoucherUsageResponse getVoucherUsageSummary(UUID consumerId, int year, int month){
         YearMonth targetMonth = YearMonth.of(year, month);
         Voucher voucher = voucherQueryRepository.findByConsumerIdAndMonth(consumerId, targetMonth);
 
-        List<VoucherUsage> completedUsage = voucherUsageQueryRepository.findByVoucherAndStatus(voucher, MatchStatus.COMPLETED);
-        List<VoucherUsage> confirmedUsage = voucherUsageQueryRepository.findByVoucherAndStatus(voucher, MatchStatus.CONFIRMED);
+        // 두 상태를 한 번에 조회
+        List<VoucherUsage> allUsage = voucherUsageQueryRepository.findByVoucherAndStatusIn(
+                voucher, List.of(MatchStatus.COMPLETED, MatchStatus.CONFIRMED)
+        );
 
-        long usedAmount = completedUsage.stream().mapToLong(VoucherUsage::getAmount).sum();
-        long expectedAmount = confirmedUsage.stream().mapToLong(VoucherUsage::getAmount).sum();
+        // 금액 계산
+        long usedAmount = allUsage.stream()
+                .filter(u -> u.getServiceMatch().getMatchStatus() == MatchStatus.COMPLETED)
+                .mapToLong(VoucherUsage::getAmount)
+                .sum();
+
+        long expectedAmount = allUsage.stream()
+                .filter(u -> u.getServiceMatch().getMatchStatus() == MatchStatus.CONFIRMED)
+                .mapToLong(VoucherUsage::getAmount)
+                .sum();
+
         long remainingAmount = voucher.getTotalAmount() - (usedAmount + expectedAmount);
 
-        long confirmedCopay = completedUsage.stream().mapToLong(VoucherUsage::getCopay).sum();
-        long totalCopay = confirmedCopay + confirmedUsage.stream().mapToLong(VoucherUsage::getCopay).sum();
-
-
-        // 두 리스트 합치기
-        List<VoucherUsage> allUsage = new ArrayList<>();
-        allUsage.addAll(completedUsage);
-        allUsage.addAll(confirmedUsage);
+        long totalCopay = allUsage.stream().mapToLong(VoucherUsage::getCopay).sum();
+        long confirmedCopay = allUsage.stream()
+                .filter(u -> u.getServiceMatch().getMatchStatus() == MatchStatus.COMPLETED)
+                .mapToLong(VoucherUsage::getCopay)
+                .sum();
 
         // 날짜 기준 정렬 (최신순)
         allUsage.sort(Comparator.comparing(u -> u.getServiceMatch().getServiceRequest().getRequestDate(), Comparator.reverseOrder()));

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/query/VoucherUsageQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/query/VoucherUsageQueryService.java
@@ -76,8 +76,9 @@ public class VoucherUsageQueryService {
                 .toList();
 
         long remainingAmount = voucher.getTotalAmount() - (cost.usedAmount() + cost.expectedAmount());
+        long totalCopay = cost.usedCopay() + cost.confirmedCopay();
 
-        return voucherUsageMapper.toVoucherUsageResponse(voucher, cost, remainingAmount, usageList);
+        return voucherUsageMapper.toVoucherUsageResponse(voucher, cost, remainingAmount, totalCopay, usageList);
     }
 
 }

--- a/homecare/src/main/java/jaega/homecare/global/config/CorsMvcConfig.java
+++ b/homecare/src/main/java/jaega/homecare/global/config/CorsMvcConfig.java
@@ -14,7 +14,9 @@ public class CorsMvcConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5173")
+                .allowedOrigins("http://localhost:5173",
+                        "http://localhost:5174", 
+                        "http://localhost:5175")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
+++ b/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
@@ -18,17 +18,21 @@ import jaega.homecare.domain.consumer.entity.CognitiveStatus;
 import jaega.homecare.domain.consumer.entity.Consumer;
 import jaega.homecare.domain.consumer.repository.ConsumerRepository;
 import jaega.homecare.domain.serviceMatch.dto.req.CreateServiceMatchRequest;
+import jaega.homecare.domain.serviceMatch.entity.MatchStatus;
+import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
 import jaega.homecare.domain.serviceMatch.service.command.ServiceMatchCommandService;
+import jaega.homecare.domain.serviceMatch.service.query.ServiceMatchQueryService;
 import jaega.homecare.domain.serviceRequest.entity.AddressType;
 import jaega.homecare.domain.serviceRequest.entity.ServiceRequest;
 import jaega.homecare.domain.serviceRequest.repository.ServiceRequestRepository;
 import jaega.homecare.domain.settlement.dto.req.CreateSettlementRequest;
-import jaega.homecare.domain.settlement.repository.SettlementRepository;
 import jaega.homecare.domain.settlement.service.command.SettlementCommandService;
 import jaega.homecare.domain.users.entity.*;
 import jaega.homecare.domain.users.repository.UserRepository;
 import jaega.homecare.domain.voucher.entity.Voucher;
 import jaega.homecare.domain.voucher.repository.VoucherRepository;
+import jaega.homecare.domain.voucher.service.query.VoucherQueryService;
+import jaega.homecare.domain.voucherUsage.service.command.VoucherUsageCommandService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -45,13 +49,15 @@ public class DummyDataService {
     private final CenterRepository centerRepository;
     private final CaregiverRepository caregiverRepository;
     private final ConsumerRepository consumerRepository;
-    private final SettlementRepository settlementRepository;
     private final VoucherRepository voucherRepository;
     private final CaregiverCenterRepository caregiverCenterRepository;
     private final ServiceRequestRepository serviceRequestRepository;
     private final CertificationRepository certificationRepository;
     private final CaregiverPreferenceRepository caregiverPreferenceRepository;
 
+    private final VoucherQueryService voucherQueryService;
+    private final ServiceMatchQueryService serviceMatchQueryService;
+    private final VoucherUsageCommandService voucherUsageCommandService;
     private final ServiceMatchCommandService serviceMatchCommandService;
     private final SettlementCommandService settlementCommandService;
     private final Random random = new Random();
@@ -326,7 +332,18 @@ public class DummyDataService {
             // ✅ 매칭 생성 후 반환값에서 serviceMatchId 가져오기
             UUID serviceMatchId = serviceMatchCommandService.createServiceMatch(createServiceMatchRequest);
 
-            // ✅ 정산 생성
+
+            // ✅ 일정 상태를 랜덤으로 CONFIRMED / CONFIRMED
+            ServiceMatch serviceMatch = serviceMatchQueryService.getServiceMatch(serviceMatchId);
+            boolean isConfirmed = random.nextBoolean(); // 50% 확률
+            serviceMatch.changeMatchStatus(isConfirmed ? MatchStatus.CONFIRMED : MatchStatus.COMPLETED);
+
+            UUID voucherId = voucherQueryService.getVoucherIdByConsumerId(consumer.getConsumerId());
+            Voucher voucher = voucherQueryService.getVoucher(voucherId);
+            voucherUsageCommandService.createVoucherUsage(voucher, serviceMatch);
+
+
+            // 정산 생성
             CreateSettlementRequest createSettlementRequest = new CreateSettlementRequest(
                     selectedCaregiverCenter.getCaregiverCenterId(),
                     serviceMatchId,

--- a/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
+++ b/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
@@ -390,14 +390,16 @@ public class DummyDataService {
             MatchStatus matchStatus = isConfirmed ? MatchStatus.CONFIRMED : MatchStatus.COMPLETED;
             serviceMatch.changeMatchStatus(matchStatus);
 
-            Review review = Review.builder()
-                    .reviewId(UUID.randomUUID())
-                    .serviceMatch(serviceMatch)
-                    .reviewScore(1.0 + (4.0 * random.nextDouble())) // 1~5점 랜덤
-                    .reviewContent("더미 리뷰 내용입니다.")
-                    .build();
+            if (matchStatus == MatchStatus.COMPLETED) {
+                Review review = Review.builder()
+                        .reviewId(UUID.randomUUID())
+                        .serviceMatch(serviceMatch)
+                        .reviewScore(1.0 + (4.0 * random.nextDouble())) // 1~5점 랜덤
+                        .reviewContent("더미 리뷰 내용입니다.")
+                        .build();
 
-            reviewRepository.save(review);
+                reviewRepository.save(review);
+            }
 
             // ✅ ServiceRequest 상태 동기화
             ServiceRequest match_serviceRequest = serviceMatch.getServiceRequest();

--- a/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
+++ b/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
@@ -82,15 +82,22 @@ public class DummyDataService {
         // 더미 센터 5개 생성
         createDummyCenter(0);
 
-        // 더미 요양보호사 생성
+        // 3. 더미 요양보호사 생성
         List<User> caregivers = userRepository.findByUserRole(UserRole.ROLE_CAREGIVER);
         IntStream.range(0, caregivers.size()).forEach(index -> createDummyCaregiver(index, caregivers));
 
-        // ✅ 4. Consumer 생성
+        // 4. Consumer 생성
         List<User> consumers = userRepository.findByUserRole(UserRole.ROLE_CONSUMER);
         IntStream.range(0, consumers.size()).forEach(index -> createDummyConsumer(index, consumers));
 
-        // ✅ 5. ServiceRequest 생성 (Consumer 기반)
+        // 4-1. dummy1@user.com 전용 Consumer 보장 생성
+        User dummyUser = userRepository.findByEmail("user1@dummy.com");
+        Consumer dummyConsumer = consumerRepository.findByUser(dummyUser);
+
+        // 전용 ServiceRequest / ServiceMatch / VoucherUsage / Review 생성
+        createDummyServiceRequestForConsumer(dummyConsumer);
+
+        // 5. ServiceRequest 생성 (Consumer 기반)
         IntStream.range(0, 30).forEach(this::createDummyServiceRequest);
     }
 
@@ -163,7 +170,13 @@ public class DummyDataService {
         caregiverRepository.save(caregiver);
 
         // CaregiverCenter 생성 (상태 랜덤)
-        CaregiverStatus status = CaregiverStatus.values()[random.nextInt(CaregiverStatus.values().length)];
+        CaregiverStatus status;
+        if (index == 0) {
+            status = CaregiverStatus.ACTIVE; // 첫 번째는 무조건 ACTIVE
+        } else {
+            status = CaregiverStatus.values()[random.nextInt(CaregiverStatus.values().length)];
+        }
+
         CaregiverCenter caregiverCenter = CaregiverCenter.builder()
                 .caregiverCenterId(UUID.randomUUID())
                 .caregiver(caregiver)
@@ -420,5 +433,73 @@ public class DummyDataService {
             );
             settlementCommandService.createSettlement(createSettlementRequest);
         }
+    }
+
+    private void createDummyServiceRequestForConsumer(Consumer consumer) {
+        // ✅ ServiceRequest 생성
+        LocalTime startTime = LocalTime.of(9, 0);
+        LocalTime endTime = LocalTime.of(12, 0);
+        LocalDate requestedDate = LocalDate.now().plusDays(1);
+
+        ServiceRequest serviceRequest = ServiceRequest.builder()
+                .consumer(consumer)
+                .serviceAddress(consumer.getResidentialAddress())
+                .addressType(AddressType.ROAD)
+                .location(new Location(37.500, 126.970))
+                .requestDate(requestedDate)
+                .preferredStartTime(startTime)
+                .preferredEndTime(endTime)
+                .duration((int) Duration.between(startTime, endTime).toHours())
+                .serviceType(ServiceType.values()[0])
+                .additionalInformation("테스트용 서비스 요청")
+                .build();
+        UUID serviceRequestId = UUID.randomUUID();
+        serviceRequest.initializeServiceRequest(serviceRequestId);
+        serviceRequestRepository.save(serviceRequest);
+
+        // ✅ ACTIVE 요양보호사 선택
+        List<Caregiver> activeCaregivers = caregiverCenterRepository.findByStatus(CaregiverStatus.ACTIVE)
+                .stream().map(CaregiverCenter::getCaregiver).toList();
+        if (activeCaregivers.isEmpty()) return;
+
+        Caregiver caregiver = activeCaregivers.get(0); // 첫 번째 ACTIVE 요양보호사
+
+        // ✅ ServiceMatch 생성
+        CreateServiceMatchRequest createServiceMatchRequest = new CreateServiceMatchRequest(
+                serviceRequestId,
+                caregiver.getCaregiverId(),
+                startTime,
+                endTime,
+                requestedDate
+        );
+        UUID serviceMatchId = serviceMatchCommandService.createServiceMatch(createServiceMatchRequest);
+
+        ServiceMatch serviceMatch = serviceMatchQueryService.getServiceMatch(serviceMatchId);
+        serviceMatch.changeMatchStatus(MatchStatus.COMPLETED); // 리뷰 가능 상태
+
+        // ✅ Review 생성
+        Review review = Review.builder()
+                .reviewId(UUID.randomUUID())
+                .serviceMatch(serviceMatch)
+                .reviewScore(5.0)
+                .reviewContent("테스트용 리뷰")
+                .build();
+        reviewRepository.save(review);
+
+        // ✅ ServiceRequest 상태 동기화
+        serviceRequest.changeRequestStatus(ServiceRequestStatus.ASSIGNED);
+
+        // ✅ VoucherUsage 생성
+        UUID voucherId = voucherQueryService.getVoucherIdByConsumerId(consumer.getConsumerId());
+        Voucher voucher = voucherQueryService.getVoucher(voucherId);
+        voucherUsageCommandService.createVoucherUsage(voucher, serviceMatch);
+
+        // ✅ Settlement 생성
+        CreateSettlementRequest createSettlementRequest = new CreateSettlementRequest(
+                caregiverCenterRepository.findByCaregiver_CaregiverId(caregiver.getCaregiverId()).get(0).getCaregiverCenterId(),
+                serviceMatchId,
+                100.0 // 테스트용 거리
+        );
+        settlementCommandService.createSettlement(createSettlementRequest);
     }
 }

--- a/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
+++ b/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
@@ -17,6 +17,11 @@ import jaega.homecare.domain.center.repository.CenterRepository;
 import jaega.homecare.domain.consumer.entity.CognitiveStatus;
 import jaega.homecare.domain.consumer.entity.Consumer;
 import jaega.homecare.domain.consumer.repository.ConsumerRepository;
+import jaega.homecare.domain.recurringOffer.entity.RecurringOffer;
+import jaega.homecare.domain.recurringOffer.entity.RecurringStatus;
+import jaega.homecare.domain.recurringOffer.repository.RecurringOfferRepository;
+import jaega.homecare.domain.review.entity.Review;
+import jaega.homecare.domain.review.repository.ReviewRepository;
 import jaega.homecare.domain.serviceMatch.dto.req.CreateServiceMatchRequest;
 import jaega.homecare.domain.serviceMatch.entity.MatchStatus;
 import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
@@ -50,7 +55,9 @@ public class DummyDataService {
     private final CenterRepository centerRepository;
     private final CaregiverRepository caregiverRepository;
     private final ConsumerRepository consumerRepository;
+    private final ReviewRepository reviewRepository;
     private final VoucherRepository voucherRepository;
+    private final RecurringOfferRepository recurringOfferRepository;
     private final CaregiverCenterRepository caregiverCenterRepository;
     private final ServiceRequestRepository serviceRequestRepository;
     private final CertificationRepository certificationRepository;
@@ -76,7 +83,6 @@ public class DummyDataService {
         // 더미 요양보호사 생성
         List<User> caregivers = userRepository.findByUserRole(UserRole.ROLE_CAREGIVER);
         IntStream.range(0, caregivers.size()).forEach(index -> createDummyCaregiver(index, caregivers));
-
 
         // ✅ 4. Consumer 생성
         List<User> consumers = userRepository.findByUserRole(UserRole.ROLE_CONSUMER);
@@ -150,8 +156,8 @@ public class DummyDataService {
                 .koreanProficiency(KoreanProficiency.values()[random.nextInt(KoreanProficiency.values().length)])
                 .isAccompanyOuting(random.nextBoolean())
                 .selfIntroduction("안녕하세요! 요양보호사 " + user.getName() + "입니다.")
-                .verifiedStatus(VerifiedStatus.PENDING)
                 .build();
+        caregiver.changeVerifiedStatus(VerifiedStatus.APPROVED);
         caregiverRepository.save(caregiver);
 
         // CaregiverCenter 생성 (상태 랜덤)
@@ -252,6 +258,50 @@ public class DummyDataService {
                 .build();
 
         voucherRepository.save(voucher);
+
+        createDummyRecurringOfferForConsumer(consumer);
+    }
+
+    private void createDummyRecurringOfferForConsumer(Consumer consumer) {
+        List<Caregiver> approvedCaregivers = caregiverRepository.findAll();
+
+        if (approvedCaregivers.isEmpty()) return;
+
+        Caregiver caregiver = approvedCaregivers.get(random.nextInt(approvedCaregivers.size()));
+
+        // 근무 요일 랜덤
+        Set<DayOfWeek> dayOfWeek = new HashSet<>();
+        int numDays = 1 + random.nextInt(5);
+        while (dayOfWeek.size() < numDays) {
+            dayOfWeek.add(DayOfWeek.values()[random.nextInt(7)]);
+        }
+
+        LocalTime startTime = LocalTime.of(9 + random.nextInt(8), 0);
+        LocalTime endTime = startTime.plusHours(3 + random.nextInt(3));
+
+        LocalDate startDate = LocalDate.now().plusDays(random.nextInt(30));
+        LocalDate endDate = startDate.plusWeeks(4 + random.nextInt(8));
+
+        ServiceType serviceType = ServiceType.values()[random.nextInt(ServiceType.values().length)];
+
+        RecurringOffer offer = RecurringOffer.builder()
+                .recurringOfferId(UUID.randomUUID())
+                .consumer(consumer)
+                .caregiver(caregiver)
+                .serviceAddress(consumer.getResidentialAddress())
+                .addressType(AddressType.ROAD)
+                .location(new Location(37.500 + random.nextDouble() * 0.1, 126.970 + random.nextDouble() * 0.1))
+                .dayOfWeek(dayOfWeek)
+                .serviceStartDate(startDate)
+                .serviceEndDate(endDate)
+                .serviceStartTime(startTime)
+                .serviceEndTime(endTime)
+                .serviceType(serviceType)
+                .recurringStatus(RecurringStatus.PENDING)
+                .recurringOfferUnread(true)
+                .build();
+
+        recurringOfferRepository.save(offer);
     }
 
     private void createDummyServiceRequest(int index) {
@@ -340,11 +390,18 @@ public class DummyDataService {
             MatchStatus matchStatus = isConfirmed ? MatchStatus.CONFIRMED : MatchStatus.COMPLETED;
             serviceMatch.changeMatchStatus(matchStatus);
 
+            Review review = Review.builder()
+                    .reviewId(UUID.randomUUID())
+                    .serviceMatch(serviceMatch)
+                    .reviewScore(1.0 + (4.0 * random.nextDouble())) // 1~5점 랜덤
+                    .reviewContent("더미 리뷰 내용입니다.")
+                    .build();
+
+            reviewRepository.save(review);
+
             // ✅ ServiceRequest 상태 동기화
             ServiceRequest match_serviceRequest = serviceMatch.getServiceRequest();
-            if (matchStatus == MatchStatus.CONFIRMED || matchStatus == MatchStatus.COMPLETED) {
-                match_serviceRequest.changeRequestStatus(ServiceRequestStatus.ASSIGNED);
-            }
+            match_serviceRequest.changeRequestStatus(ServiceRequestStatus.ASSIGNED);
 
             UUID voucherId = voucherQueryService.getVoucherIdByConsumerId(consumer.getConsumerId());
             Voucher voucher = voucherQueryService.getVoucher(voucherId);

--- a/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
+++ b/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
@@ -24,6 +24,7 @@ import jaega.homecare.domain.serviceMatch.service.command.ServiceMatchCommandSer
 import jaega.homecare.domain.serviceMatch.service.query.ServiceMatchQueryService;
 import jaega.homecare.domain.serviceRequest.entity.AddressType;
 import jaega.homecare.domain.serviceRequest.entity.ServiceRequest;
+import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
 import jaega.homecare.domain.serviceRequest.repository.ServiceRequestRepository;
 import jaega.homecare.domain.settlement.dto.req.CreateSettlementRequest;
 import jaega.homecare.domain.settlement.service.command.SettlementCommandService;
@@ -336,7 +337,14 @@ public class DummyDataService {
             // ✅ 일정 상태를 랜덤으로 CONFIRMED / CONFIRMED
             ServiceMatch serviceMatch = serviceMatchQueryService.getServiceMatch(serviceMatchId);
             boolean isConfirmed = random.nextBoolean(); // 50% 확률
-            serviceMatch.changeMatchStatus(isConfirmed ? MatchStatus.CONFIRMED : MatchStatus.COMPLETED);
+            MatchStatus matchStatus = isConfirmed ? MatchStatus.CONFIRMED : MatchStatus.COMPLETED;
+            serviceMatch.changeMatchStatus(matchStatus);
+
+            // ✅ ServiceRequest 상태 동기화
+            ServiceRequest match_serviceRequest = serviceMatch.getServiceRequest();
+            if (matchStatus == MatchStatus.CONFIRMED || matchStatus == MatchStatus.COMPLETED) {
+                match_serviceRequest.changeRequestStatus(ServiceRequestStatus.ASSIGNED);
+            }
 
             UUID voucherId = voucherQueryService.getVoucherIdByConsumerId(consumer.getConsumerId());
             Voucher voucher = voucherQueryService.getVoucher(voucherId);

--- a/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
+++ b/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
@@ -25,6 +25,7 @@ import jaega.homecare.domain.review.repository.ReviewRepository;
 import jaega.homecare.domain.serviceMatch.dto.req.CreateServiceMatchRequest;
 import jaega.homecare.domain.serviceMatch.entity.MatchStatus;
 import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
+import jaega.homecare.domain.serviceMatch.repository.ServiceMatchQueryRepository;
 import jaega.homecare.domain.serviceMatch.service.command.ServiceMatchCommandService;
 import jaega.homecare.domain.serviceMatch.service.query.ServiceMatchQueryService;
 import jaega.homecare.domain.serviceRequest.entity.AddressType;
@@ -60,6 +61,7 @@ public class DummyDataService {
     private final VoucherRepository voucherRepository;
     private final RecurringOfferRepository recurringOfferRepository;
     private final CaregiverCenterRepository caregiverCenterRepository;
+    private final ServiceMatchQueryRepository serviceMatchQueryRepository;
     private final ServiceRequestRepository serviceRequestRepository;
     private final CertificationRepository certificationRepository;
     private final CaregiverPreferenceRepository caregiverPreferenceRepository;
@@ -338,8 +340,8 @@ public class DummyDataService {
             serviceEndTime = LocalTime.of(20, 0);
         }
 
-        // ✅ 요청 날짜 → 한 개만 랜덤으로 설정 (미래 날짜)
-        LocalDate requestedDate = LocalDate.now().plusDays(random.nextInt(3) + 1);
+        // ✅ 요청 날짜 → +-2일로 생성되도록 변경
+        LocalDate requestedDate = LocalDate.now().plusDays(random.nextInt(5) - 2);
 
         // 3. Duration 계산 (시간 차)
         int duration = (int) java.time.Duration.between(serviceStartTime, serviceEndTime).toHours();
@@ -400,11 +402,17 @@ public class DummyDataService {
 
 
             // ✅ 일정 상태를 랜덤으로 CONFIRMED / CONFIRMED
+            // ✅ 일정 상태 결정: 날짜 기준
             ServiceMatch serviceMatch = serviceMatchQueryService.getServiceMatch(serviceMatchId);
-            boolean isConfirmed = random.nextBoolean(); // 50% 확률
-            MatchStatus matchStatus = isConfirmed ? MatchStatus.CONFIRMED : MatchStatus.COMPLETED;
+            MatchStatus matchStatus;
+            if (requestedDate.isAfter(LocalDate.now())) {
+                matchStatus = MatchStatus.CONFIRMED;
+            } else {
+                matchStatus = MatchStatus.COMPLETED;
+            }
             serviceMatch.changeMatchStatus(matchStatus);
 
+            // COMPLETED인 경우에만 리뷰 생성
             if (matchStatus == MatchStatus.COMPLETED) {
                 Review review = Review.builder()
                         .reviewId(UUID.randomUUID())
@@ -420,10 +428,6 @@ public class DummyDataService {
             ServiceRequest match_serviceRequest = serviceMatch.getServiceRequest();
             match_serviceRequest.changeRequestStatus(ServiceRequestStatus.ASSIGNED);
 
-            UUID voucherId = voucherQueryService.getVoucherIdByConsumerId(consumer.getConsumerId());
-            Voucher voucher = voucherQueryService.getVoucher(voucherId);
-            voucherUsageCommandService.createVoucherUsage(voucher, serviceMatch);
-
 
             // 정산 생성
             CreateSettlementRequest createSettlementRequest = new CreateSettlementRequest(
@@ -436,70 +440,92 @@ public class DummyDataService {
     }
 
     private void createDummyServiceRequestForConsumer(Consumer consumer) {
-        // ✅ ServiceRequest 생성
-        LocalTime startTime = LocalTime.of(9, 0);
-        LocalTime endTime = LocalTime.of(12, 0);
-        LocalDate requestedDate = LocalDate.now().plusDays(1);
+        // user3@dummy.com 요양보호사 조회
+        User user = userRepository.findByEmail("user3@dummy.com");
+        if (user == null) return;
 
-        ServiceRequest serviceRequest = ServiceRequest.builder()
-                .consumer(consumer)
-                .serviceAddress(consumer.getResidentialAddress())
-                .addressType(AddressType.ROAD)
-                .location(new Location(37.500, 126.970))
-                .requestDate(requestedDate)
-                .preferredStartTime(startTime)
-                .preferredEndTime(endTime)
-                .duration((int) Duration.between(startTime, endTime).toHours())
-                .serviceType(ServiceType.values()[0])
-                .additionalInformation("테스트용 서비스 요청")
-                .build();
-        UUID serviceRequestId = UUID.randomUUID();
-        serviceRequest.initializeServiceRequest(serviceRequestId);
-        serviceRequestRepository.save(serviceRequest);
+        Caregiver caregiver = caregiverRepository.findByUser(user);
+        if (caregiver == null) return;
 
-        // ✅ ACTIVE 요양보호사 선택
-        List<Caregiver> activeCaregivers = caregiverCenterRepository.findByStatus(CaregiverStatus.ACTIVE)
-                .stream().map(CaregiverCenter::getCaregiver).toList();
-        if (activeCaregivers.isEmpty()) return;
+        // 날짜 범위: 오늘 기준 -4일 ~ +4일
+        List<LocalDate> possibleDates = IntStream.rangeClosed(-4, 4)
+                .mapToObj(i -> LocalDate.now().plusDays(i))
+                .toList();
 
-        Caregiver caregiver = activeCaregivers.get(0); // 첫 번째 ACTIVE 요양보호사
-
-        // ✅ ServiceMatch 생성
-        CreateServiceMatchRequest createServiceMatchRequest = new CreateServiceMatchRequest(
-                serviceRequestId,
-                caregiver.getCaregiverId(),
-                startTime,
-                endTime,
-                requestedDate
+        // 시간대
+        List<LocalTime[]> timeSlots = List.of(
+                new LocalTime[]{LocalTime.of(9, 0), LocalTime.of(12, 0)},
+                new LocalTime[]{LocalTime.of(13, 0), LocalTime.of(16, 0)},
+                new LocalTime[]{LocalTime.of(17, 0), LocalTime.of(20, 0)}
         );
-        UUID serviceMatchId = serviceMatchCommandService.createServiceMatch(createServiceMatchRequest);
 
-        ServiceMatch serviceMatch = serviceMatchQueryService.getServiceMatch(serviceMatchId);
-        serviceMatch.changeMatchStatus(MatchStatus.COMPLETED); // 리뷰 가능 상태
+        for (LocalDate date : possibleDates) {
+            for (LocalTime[] slot : timeSlots) {
+                LocalTime startTime = slot[0];
+                LocalTime endTime = slot[1];
 
-        // ✅ Review 생성
-        Review review = Review.builder()
-                .reviewId(UUID.randomUUID())
-                .serviceMatch(serviceMatch)
-                .reviewScore(5.0)
-                .reviewContent("테스트용 리뷰")
-                .build();
-        reviewRepository.save(review);
+                // 중복 체크
+                if (serviceMatchQueryRepository.existsByCaregiverAndDateTime(caregiver.getCaregiverId(), date, startTime, endTime)) {
+                    continue; // 이미 겹치면 스킵
+                }
 
-        // ✅ ServiceRequest 상태 동기화
-        serviceRequest.changeRequestStatus(ServiceRequestStatus.ASSIGNED);
+                // ServiceRequest 생성
+                ServiceRequest serviceRequest = ServiceRequest.builder()
+                        .consumer(consumer)
+                        .serviceAddress(consumer.getResidentialAddress())
+                        .addressType(AddressType.ROAD)
+                        .location(new Location(37.500, 126.970))
+                        .requestDate(date)
+                        .preferredStartTime(startTime)
+                        .preferredEndTime(endTime)
+                        .duration((int) Duration.between(startTime, endTime).toHours())
+                        .serviceType(ServiceType.values()[0])
+                        .additionalInformation("테스트용 서비스 요청")
+                        .build();
 
-        // ✅ VoucherUsage 생성
-        UUID voucherId = voucherQueryService.getVoucherIdByConsumerId(consumer.getConsumerId());
-        Voucher voucher = voucherQueryService.getVoucher(voucherId);
-        voucherUsageCommandService.createVoucherUsage(voucher, serviceMatch);
+                UUID serviceRequestId = UUID.randomUUID();
+                serviceRequest.initializeServiceRequest(serviceRequestId);
+                serviceRequestRepository.save(serviceRequest);
 
-        // ✅ Settlement 생성
-        CreateSettlementRequest createSettlementRequest = new CreateSettlementRequest(
-                caregiverCenterRepository.findByCaregiver_CaregiverId(caregiver.getCaregiverId()).get(0).getCaregiverCenterId(),
-                serviceMatchId,
-                100.0 // 테스트용 거리
-        );
-        settlementCommandService.createSettlement(createSettlementRequest);
+                // ServiceMatch 생성
+                CreateServiceMatchRequest matchRequest = new CreateServiceMatchRequest(
+                        serviceRequestId,
+                        caregiver.getCaregiverId(),
+                        startTime,
+                        endTime,
+                        date
+                );
+                UUID serviceMatchId = serviceMatchCommandService.createServiceMatch(matchRequest);
+
+                ServiceMatch serviceMatch = serviceMatchQueryService.getServiceMatch(serviceMatchId);
+
+                // 상태: 오늘 이후면 CONFIRMED, 이전이면 COMPLETED
+                if (date.isAfter(LocalDate.now()) || date.isEqual(LocalDate.now())) {
+                    serviceMatch.changeMatchStatus(MatchStatus.CONFIRMED);
+                } else {
+                    serviceMatch.changeMatchStatus(MatchStatus.COMPLETED);
+
+                    // COMPLETED이면 리뷰 생성
+                    Review review = Review.builder()
+                            .reviewId(UUID.randomUUID())
+                            .serviceMatch(serviceMatch)
+                            .reviewScore(5.0)
+                            .reviewContent("테스트용 리뷰")
+                            .build();
+                    reviewRepository.save(review);
+                }
+
+                // ServiceRequest 상태 동기화
+                serviceRequest.changeRequestStatus(ServiceRequestStatus.ASSIGNED);
+
+                // Settlement 생성
+                CreateSettlementRequest settlementRequest = new CreateSettlementRequest(
+                        caregiverCenterRepository.findByCaregiver_CaregiverId(caregiver.getCaregiverId()).get(0).getCaregiverCenterId(),
+                        serviceMatchId,
+                        100.0
+                );
+                settlementCommandService.createSettlement(settlementRequest);
+            }
+        }
     }
 }

--- a/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
+++ b/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
@@ -37,6 +37,7 @@ import jaega.homecare.domain.users.entity.*;
 import jaega.homecare.domain.users.repository.UserRepository;
 import jaega.homecare.domain.voucher.entity.Voucher;
 import jaega.homecare.domain.voucher.repository.VoucherRepository;
+import jaega.homecare.domain.voucher.service.command.VoucherCommandService;
 import jaega.homecare.domain.voucher.service.query.VoucherQueryService;
 import jaega.homecare.domain.voucherUsage.service.command.VoucherUsageCommandService;
 import jakarta.transaction.Transactional;
@@ -67,6 +68,7 @@ public class DummyDataService {
     private final ServiceMatchQueryService serviceMatchQueryService;
     private final VoucherUsageCommandService voucherUsageCommandService;
     private final ServiceMatchCommandService serviceMatchCommandService;
+    private final VoucherCommandService voucherCommandService;
     private final SettlementCommandService settlementCommandService;
     private final Random random = new Random();
 
@@ -248,7 +250,7 @@ public class DummyDataService {
         consumerRepository.save(consumer);
 
         // ✅ Consumer 생성 시 Voucher 생성
-        long totalAmount = getTotalAmountByCareGrade(consumer.getCareGrade());
+        Long totalAmount = voucherCommandService.getTotalAmountByCareGrade(consumer.getCareGrade());
 
         Voucher voucher = Voucher.builder()
                 .voucherId(UUID.randomUUID())
@@ -418,16 +420,5 @@ public class DummyDataService {
             );
             settlementCommandService.createSettlement(createSettlementRequest);
         }
-    }
-
-    private long getTotalAmountByCareGrade(int careGrade) {
-        return switch (careGrade) {
-            case 1 -> 1_520_700L;
-            case 2 -> 1_351_700L;
-            case 3 -> 1_295_400L;
-            case 4 -> 1_189_800L;
-            case 5 -> 1_021_300L;
-            default -> 573_900L; // 인지지원등급
-        };
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #61 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 1. Consumer의 마이페이지용 바우처 내역 조회 API를 추가했습니다.
- 바우처 내역 조회는 기획 요구사항에 맞게 매칭 상태를 기준으로 조회합니다.
- 매칭 상태가 PENDING인 상태는 조회하지 않고, CONFIRMED, COMPLETED를 기준으로만 조회합니다.
- 금액 계산 시에는 예정된 금액은 CONFIREMD, 완료된 금액은 COMPLETED 상태를 기준으로 조회합니다.

### 2. 더미 데이터 생성 로직을 다음과 같이 추가했습니다.
- Review 관련 매칭이 완료된 데이터들만 더미 데이터 생성
- RecurringOffer 관련 더미 데이터 생성 ( PENDING 상태 )
- Voucher, VoucherUsage 관련 사용자 등급 기준 더미 데이터 생성

### 3. 바우처 내역을 생성하는 Service를 추가했습니다.
- 더미 데이터 생성을 위해 바우처 내역을 생성하는 서비스를 추가했습니다.
- ServiceFee 클래스를 이용해 서비스 유형마다 금액, 본인부담금을 부과하도록 했습니다. (현재는 방문 요양 기준)

### 4. (메인 페이지) Consumer의 거절된 일정 조회를 구현했습니다.
- 거절된 일정 조회 관련 시나리오는 다음과 같이 구현했습니다.
1. Consumer가 거절된 일정을 조회함
2.1 거절된 일정(매칭)의 서비스 신청을 취소함
2.2 거절된 일정을 다시 재매칭함

현재는 1번, 2.1번을 구현하였으며 2.2는 매칭 알고리즘 연동 시 구현될 예정입니다.

### 5. Consumer의 회원가입 시 바우처를 생성하는 로직을 구현했습니다!
- Consumer의 회원가입 시에 등급에 맞는 월별 바우처 금액을 생성하도록 했습니다.
(다른 API에서 불러올 수 없어, 테스트 환경으로 보여주기 위함)

### 스크린샷 (선택)

<br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
