### PR TITLE
[#63] 프론트엔드 연동 과정 오류 해결 및 더미 데이터 추가 

### DIFF
--- a/homecare/src/main/java/jaega/homecare/domain/consumer/controller/ConsumerControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/consumer/controller/ConsumerControllerImpl.java
@@ -240,8 +240,8 @@ public class ConsumerControllerImpl implements ConsumerController {
 
     // 정기 제안 상세 조회 API
     @Override
-    public ResponseEntity<GetRecurringOfferDetailResponse> getRecurringOfferDetail(@PathVariable UUID recurringOfferId){
-        GetRecurringOfferDetailResponse response = recurringOfferQueryService.findRecurringOfferDetail(recurringOfferId);
+    public ResponseEntity<GetRecurringOfferDetailResponse> getRecurringOfferDetail(@PathVariable UUID recurringId){
+        GetRecurringOfferDetailResponse response = recurringOfferQueryService.findRecurringOfferDetail(recurringId);
         return ResponseEntity.ok(response);
     }
 

--- a/homecare/src/main/java/jaega/homecare/domain/recurringOffer/service/command/RecurringOfferCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/recurringOffer/service/command/RecurringOfferCommandService.java
@@ -11,8 +11,10 @@ import jaega.homecare.domain.recurringOffer.mapper.RecurringOfferMapper;
 import jaega.homecare.domain.recurringOffer.repository.RecurringOfferRepository;
 import jaega.homecare.domain.recurringOffer.service.query.RecurringOfferQueryService;
 import jaega.homecare.domain.serviceMatch.dto.req.CreateServiceMatchRequest;
+import jaega.homecare.domain.serviceMatch.entity.MatchStatus;
 import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
 import jaega.homecare.domain.serviceMatch.service.command.ServiceMatchCommandService;
+import jaega.homecare.domain.serviceMatch.service.query.ServiceMatchQueryService;
 import jaega.homecare.domain.serviceRequest.dto.req.ConsumerServiceRequest;
 import jaega.homecare.domain.serviceRequest.dto.res.GetCreateServiceResponse;
 import jaega.homecare.domain.serviceRequest.entity.ServiceRequest;
@@ -40,6 +42,7 @@ public class RecurringOfferCommandService {
     private final ServiceRequestQueryService serviceRequestQueryService;
     private final ServiceRequestCommandService serviceRequestCommandService;
     private final ServiceMatchCommandService serviceMatchCommandService;
+    private final ServiceMatchQueryService serviceMatchQueryService;
 
     /**
      * 수요자 ( consumer )
@@ -91,7 +94,9 @@ public class RecurringOfferCommandService {
                         recurringOffer.getServiceEndTime(),
                         currentDate
                 );
-                serviceMatchCommandService.createServiceMatch(request);
+                UUID serviceMatchId = serviceMatchCommandService.createServiceMatch(request);
+                ServiceMatch serviceMatch = serviceMatchQueryService.getServiceMatch(serviceMatchId);
+                serviceMatch.changeMatchStatus(MatchStatus.CONFIRMED);
             }
             currentDate = currentDate.plusDays(1);
         }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/repository/ServiceMatchQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/repository/ServiceMatchQueryRepository.java
@@ -510,13 +510,13 @@ public class ServiceMatchQueryRepository {
         QServiceMatch serviceMatch = QServiceMatch.serviceMatch;
         QServiceRequest serviceRequest = QServiceRequest.serviceRequest;
         QCaregiver caregiver = QCaregiver.caregiver;
-        QUser caregiverUser = caregiver.user;
         QReview review = QReview.review;
 
         return queryFactory
                 .select(Projections.constructor(
                         GetScheduleWithoutReviewResponse.class,
-                        caregiverUser.name,
+                        serviceMatch.serviceMatchId,
+                        serviceMatch.caregiver.user.name,
                         serviceMatch.serviceDate,
                         serviceMatch.serviceStartTime,
                         serviceMatch.serviceEndTime,
@@ -525,7 +525,6 @@ public class ServiceMatchQueryRepository {
                 .from(serviceMatch)
                 .join(serviceMatch.serviceRequest, serviceRequest)
                 .join(serviceMatch.caregiver, caregiver)
-                .join(caregiver.user, caregiverUser)
                 .leftJoin(review).on(review.serviceMatch.eq(serviceMatch))
                 .where(
                         serviceRequest.consumer.consumerId.eq(consumerId),

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/repository/VoucherUsageQueryRepository.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/repository/VoucherUsageQueryRepository.java
@@ -88,7 +88,7 @@ public class VoucherUsageQueryRepository {
             }
         }
 
-        return new VoucherUsageCost(usedAmount, expectedAmount, confirmedCopay, usedCopay);
+        return new VoucherUsageCost(usedAmount, usedCopay, expectedAmount, confirmedCopay);
     }
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/query/VoucherUsageQueryService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/voucherUsage/service/query/VoucherUsageQueryService.java
@@ -75,8 +75,18 @@ public class VoucherUsageQueryService {
                 .map(voucherUsageMapper::toVoucherUsageDetail)
                 .toList();
 
-        long remainingAmount = voucher.getTotalAmount() - (cost.usedAmount() + cost.expectedAmount());
-        long totalCopay = cost.usedCopay() + cost.confirmedCopay();
+        // 실제 바우처 사용액: 바우처 총액을 초과하지 않도록
+        long totalUsed = cost.usedAmount() + cost.expectedAmount();
+        long actualVoucherUsed = Math.min(voucher.getTotalAmount(), totalUsed);
+
+        // 초과분은 본인 부담금으로 반영
+        long extraCopay = Math.max(0, totalUsed - voucher.getTotalAmount());
+
+        // 남은 바우처 금액
+        long remainingAmount = voucher.getTotalAmount() - actualVoucherUsed;
+
+        // 총 본인 부담금
+        long totalCopay = cost.usedCopay() + cost.confirmedCopay() + extraCopay;
 
         return voucherUsageMapper.toVoucherUsageResponse(voucher, cost, remainingAmount, totalCopay, usageList);
     }

--- a/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
+++ b/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
@@ -440,12 +440,15 @@ public class DummyDataService {
     }
 
     private void createDummyServiceRequestForConsumer(Consumer consumer) {
-        // user3@dummy.com 요양보호사 조회
-        User user = userRepository.findByEmail("user3@dummy.com");
-        if (user == null) return;
+        // 전체 ACTIVE 요양보호사 조회
+        List<Caregiver> activeCaregivers = caregiverCenterRepository.findByStatus(CaregiverStatus.ACTIVE)
+                .stream()
+                .map(CaregiverCenter::getCaregiver)
+                .distinct()
+                .limit(10) // 앞 10명만
+                .toList();
 
-        Caregiver caregiver = caregiverRepository.findByUser(user);
-        if (caregiver == null) return;
+        if (activeCaregivers.isEmpty()) return;
 
         // 날짜 범위: 오늘 기준 -4일 ~ +4일
         List<LocalDate> possibleDates = IntStream.rangeClosed(-4, 4)
@@ -463,6 +466,9 @@ public class DummyDataService {
             for (LocalTime[] slot : timeSlots) {
                 LocalTime startTime = slot[0];
                 LocalTime endTime = slot[1];
+
+                // 랜덤으로 매칭할 요양보호사 선택
+                Caregiver caregiver = activeCaregivers.get(random.nextInt(activeCaregivers.size()));
 
                 // 중복 체크
                 if (serviceMatchQueryRepository.existsByCaregiverAndDateTime(caregiver.getCaregiverId(), date, startTime, endTime)) {
@@ -499,7 +505,7 @@ public class DummyDataService {
 
                 ServiceMatch serviceMatch = serviceMatchQueryService.getServiceMatch(serviceMatchId);
 
-                // 상태: 오늘 이후면 CONFIRMED, 이전이면 COMPLETED
+                // 상태 결정
                 if (date.isAfter(LocalDate.now()) || date.isEqual(LocalDate.now())) {
                     serviceMatch.changeMatchStatus(MatchStatus.CONFIRMED);
                 } else {

--- a/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
+++ b/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
@@ -81,7 +81,7 @@ public class DummyDataService {
 
         // 2. Center와 Caregiver는 USER 데이터에 의존하므로, USER 생성 후 실행
 
-        // 더미 센터 5개 생성
+        // 더미 센터 생성
         createDummyCenter(0);
 
         // 3. 더미 요양보호사 생성
@@ -117,8 +117,13 @@ public class DummyDataService {
         String emailPrefix = "user" + index;
         String email = emailPrefix + "@dummy.com";
 
-        UserRole role = index % 5 == 0 ? UserRole.ROLE_CENTER :
-                (index % 3 == 0 ? UserRole.ROLE_CAREGIVER : UserRole.ROLE_CONSUMER);
+        UserRole role;
+        if (index == 0) {
+            role = UserRole.ROLE_CENTER; // 0번은 센터
+        } else {
+            // 나머지는 CAREGIVER 또는 CONSUMER로 분기
+            role = (index % 2 == 0) ? UserRole.ROLE_CAREGIVER : UserRole.ROLE_CONSUMER;
+        }
 
         User user = User.builder()
                 .name(name)

--- a/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
+++ b/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
@@ -20,6 +20,7 @@ import jaega.homecare.domain.consumer.repository.ConsumerRepository;
 import jaega.homecare.domain.recurringOffer.entity.RecurringOffer;
 import jaega.homecare.domain.recurringOffer.entity.RecurringStatus;
 import jaega.homecare.domain.recurringOffer.repository.RecurringOfferRepository;
+import jaega.homecare.domain.recurringOffer.service.command.RecurringOfferCommandService;
 import jaega.homecare.domain.review.entity.Review;
 import jaega.homecare.domain.review.repository.ReviewRepository;
 import jaega.homecare.domain.serviceMatch.dto.req.CreateServiceMatchRequest;
@@ -40,12 +41,12 @@ import jaega.homecare.domain.voucher.entity.Voucher;
 import jaega.homecare.domain.voucher.repository.VoucherRepository;
 import jaega.homecare.domain.voucher.service.command.VoucherCommandService;
 import jaega.homecare.domain.voucher.service.query.VoucherQueryService;
-import jaega.homecare.domain.voucherUsage.service.command.VoucherUsageCommandService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.*;
+import java.time.temporal.TemporalAdjusters;
 import java.util.*;
 import java.util.stream.IntStream;
 
@@ -68,7 +69,7 @@ public class DummyDataService {
 
     private final VoucherQueryService voucherQueryService;
     private final ServiceMatchQueryService serviceMatchQueryService;
-    private final VoucherUsageCommandService voucherUsageCommandService;
+    private final RecurringOfferCommandService recurringOfferCommandService;
     private final ServiceMatchCommandService serviceMatchCommandService;
     private final VoucherCommandService voucherCommandService;
     private final SettlementCommandService settlementCommandService;
@@ -284,10 +285,10 @@ public class DummyDataService {
         createDummyRecurringOfferForConsumer(consumer);
     }
 
-    private void createDummyRecurringOfferForConsumer(Consumer consumer) {
+    private UUID createDummyRecurringOfferForConsumer(Consumer consumer) {
         List<Caregiver> approvedCaregivers = caregiverRepository.findAll();
 
-        if (approvedCaregivers.isEmpty()) return;
+        if (approvedCaregivers.isEmpty()) return null;
 
         Caregiver caregiver = approvedCaregivers.get(random.nextInt(approvedCaregivers.size()));
 
@@ -324,6 +325,7 @@ public class DummyDataService {
                 .build();
 
         recurringOfferRepository.save(offer);
+        return offer.getRecurringOfferId();
     }
 
     private void createDummyServiceRequest(int index) {
@@ -538,5 +540,8 @@ public class DummyDataService {
                 settlementCommandService.createSettlement(settlementRequest);
             }
         }
+        UUID recurringOfferId = createDummyRecurringOfferForConsumer(consumer);
+
+        recurringOfferCommandService.approveRecurringStatus(recurringOfferId);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #63 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 1. 프론트엔드 연동 과정 오류 해결 
- 바우처 내역의 totalCopay가 너무 높게 계산되고있음
-> responseDto로 매핑 시 잘못된 금액으로 매핑되고 있었습니다.

- 지나친 바우처 내역 사용으로 남은 바우처 금액이 -가 됨
-> 바우처 사용 금액을 초과한 분은 본인 부담금으로 전환되도록 함 
(데이터 상의 문제이며, 실 서비스에선 검증을 하면 될 것 같습니다.)
- 메인 페이지의 리뷰가 필요한 일정 조회가 실행되지 않는 문제 ( 조인 )
-> queryDSL에서 타입이 일치하지 않아 이름을 요양보호사에서 조회하도록 했습니다.

- 특정 수요자의 일정 생성 시 한 요양보호사의 일정만 매칭됨
-> 10명의 요양보호사 중 랜덤으로 일정에 반영하도록 했습니다.

- 수요자의 정기 제안 상세 조회의 잘못된 Pathvariable 매핑
-> 입력값은 recurringOfferId인데 Pathvariable에선 {recurringId}로 되어있었습니다.

### 2. 더미 데이터 생성 추가
- 더미 데이터 생성 시 프론트엔드 연동용 수요자의 정기 제안 데이터도 생성하도록 했습니다.
- 정기 제안 데이터가 생성된 후, 곧바로 정기 제안을 승인하여 일정에 반영하도록 했습니다.
(시작 날짜 : 다음 주~ 다음주 + 8주, 요일 개수는 랜덤)

### 스크린샷 (선택)

<br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
