### PR TITLE
[#59] 요양보호사 관련 api 및 매칭 연동을 위한 로직 추가 

### DIFF
--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverController.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverController.java
@@ -106,6 +106,11 @@ public interface CaregiverController {
     @GetMapping("/home/next-schedule")
     ResponseEntity<List<CaregiverScheduleResponse>> getTomorrowSchedule(@RequestParam UUID caregiverId);
 
+    @Operation(summary = "요양보호사 일정 거절 API", description = "요양보호사가 선택된 단발 일정을 거절합니다.")
+    @ApiResponse(responseCode = "204", description = "요양보호사 일정 거절 성공")
+    @PostMapping("/schedule/reject")
+    ResponseEntity<Void> rejectScheduleReject(@RequestParam UUID serviceMatchId);
+
     /**
      *
      * 리뷰 조회 API

--- a/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/caregiver/controller/CaregiverControllerImpl.java
@@ -14,6 +14,7 @@ import jaega.homecare.domain.review.dto.res.CaregiverReviewDetailResponse;
 import jaega.homecare.domain.review.dto.res.CaregiverReviewSummaryResponse;
 import jaega.homecare.domain.review.service.query.ReviewQueryService;
 import jaega.homecare.domain.serviceMatch.entity.ServiceMatch;
+import jaega.homecare.domain.serviceMatch.service.command.ServiceMatchCommandService;
 import jaega.homecare.domain.serviceMatch.service.query.ServiceMatchQueryService;
 import jaega.homecare.domain.settlement.dto.req.CreateSettlementRequest;
 import jaega.homecare.domain.settlement.dto.res.GetCaregiverCenterSettlementResponse;
@@ -38,6 +39,7 @@ public class CaregiverControllerImpl implements CaregiverController {
     private final SettlementCommandService settlementCommandService;
     private final SettlementQueryService settlementQueryService;
     private final ServiceMatchQueryService serviceMatchQueryService;
+    private final ServiceMatchCommandService serviceMatchCommandService;
     private final CaregiverCenterQueryService caregiverCenterQueryService;
     private final CaregiverCommandService caregiverCommandService;
     private final CaregiverQueryService caregiverQueryService;
@@ -157,6 +159,16 @@ public class CaregiverControllerImpl implements CaregiverController {
         List<CaregiverScheduleResponse> responses = serviceMatchQueryService.getCaregiverScheduleByDate(caregiverId, tomorrow);
         return ResponseEntity.ok(responses);
     }
+
+    // 요양보호사에게 확정된 단발 일정을 거절
+    @Override
+    public ResponseEntity<Void> rejectScheduleReject(UUID serviceMatchId) {
+        ServiceMatch serviceMatch = serviceMatchQueryService.getServiceMatch(serviceMatchId);
+        serviceMatchCommandService.rejectMatchStatus(serviceMatch);
+
+        return ResponseEntity.noContent().build();
+    }
+
 
     /**
      *  리뷰 조회 API

--- a/homecare/src/main/java/jaega/homecare/domain/match/controller/MatchControllerImpl.java
+++ b/homecare/src/main/java/jaega/homecare/domain/match/controller/MatchControllerImpl.java
@@ -39,7 +39,12 @@ public class MatchControllerImpl implements MatchController {
 
     @Override
     public ResponseEntity<MatchingResponseDTO> matchingProcess(UUID serviceRequestId) {
+        /*
          MatchingResponseDTO response = caregiverMatchingService.recommendCaregivers(serviceRequestId);
          return ResponseEntity.ok(response);
+
+         */
+
+        return null;
     }
 }

--- a/homecare/src/main/java/jaega/homecare/domain/match/infra/MatchingGrpcClient.java
+++ b/homecare/src/main/java/jaega/homecare/domain/match/infra/MatchingGrpcClient.java
@@ -4,12 +4,14 @@ import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import jaega.homecare.domain.match.dto.req.MatchRequest;
 import jaega.homecare.domain.match.dto.res.MatchingResponseDTO;
+import matching.MatchingServiceGrpc;
+import matching.MatchingServiceOuterClass;
 import org.springframework.stereotype.Service;
 
 @Service
 public class MatchingGrpcClient {
 
-    /*
+/*
     private final MatchingServiceGrpc.MatchingServiceBlockingStub stub;
 
     public MatchingGrpcClient() {
@@ -19,23 +21,23 @@ public class MatchingGrpcClient {
         this.stub = MatchingServiceGrpc.newBlockingStub(channel);
     }
 
-     */
 
-    public MatchingResponseDTO getMatchingRecommendations(MatchRequest request) {
-        return null;
-     //   return stub.getMatchingRecommendations(request);
+
+    public MatchingServiceOuterClass.MatchingResponse getMatchingRecommendations(MatchingServiceOuterClass.MatchingRequest request) {
+        return stub.getMatchingRecommendations(request);
     }
 
-    /*
-    public HealthCheckResponse healthCheck() {
-        HealthCheckRequest request = HealthCheckRequest.newBuilder()
+    public MatchingServiceOuterClass.HealthCheckResponse healthCheck() {
+        MatchingServiceOuterClass.HealthCheckRequest request = MatchingServiceOuterClass.HealthCheckRequest.newBuilder()
                 .setService("matching")
                 .build();
         return stub.healthCheck(request);
     }
 
+ */
 
-     */
+
+
 
 
 }

--- a/homecare/src/main/java/jaega/homecare/domain/match/service/CaregiverMatchingService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/match/service/CaregiverMatchingService.java
@@ -8,18 +8,23 @@ import jaega.homecare.domain.caregiverPreference.service.query.CaregiverPreferen
 import jaega.homecare.domain.match.dto.req.CaregiverDTO;
 import jaega.homecare.domain.match.dto.req.MatchRequest;
 import jaega.homecare.domain.match.dto.req.ServiceRequestDTO;
+import jaega.homecare.domain.match.dto.res.MatchedCaregiverDTO;
 import jaega.homecare.domain.match.dto.res.MatchingResponseDTO;
 import jaega.homecare.domain.match.infra.MatchingGrpcClient;
 import jaega.homecare.domain.serviceRequest.entity.ServiceRequest;
+import jaega.homecare.domain.serviceRequest.entity.ServiceRequestStatus;
 import jaega.homecare.domain.serviceRequest.service.query.ServiceRequestQueryService;
 import lombok.RequiredArgsConstructor;
+import matching.MatchingServiceOuterClass;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class CaregiverMatchingService {
+    /*
 
     private final ServiceRequestQueryService serviceRequestQueryService;
     private final CaregiverCenterQueryRepository caregiverCenterQueryRepository;
@@ -38,7 +43,12 @@ public class CaregiverMatchingService {
                 candidateCaregivers
         );
 
-        return matchingGrpcClient.getMatchingRecommendations(matchRequest);
+        MatchingServiceOuterClass.MatchingRequest grpcRequest =
+                toProto(serviceRequestDTO, candidateCaregivers);
+
+
+        MatchingServiceOuterClass.MatchingResponse response = matchingGrpcClient.getMatchingRecommendations(grpcRequest);
+        return toDto(response);
     }
 
     private List<CaregiverDTO> convertCaregiverToDTO(List<Caregiver> caregivers) {
@@ -97,4 +107,82 @@ public class CaregiverMatchingService {
                 serviceRequest.getAdditionalInformation()
         );
     }
+
+    public static MatchingServiceOuterClass.MatchingRequest toProto(
+            ServiceRequestDTO serviceRequestDTO,
+            List<CaregiverDTO> caregivers
+    ) {
+        // ServiceRequest 변환
+        MatchingServiceOuterClass.ServiceRequest serviceRequest =
+                MatchingServiceOuterClass.ServiceRequest.newBuilder()
+                        .setServiceRequestId(serviceRequestDTO.serviceRequestId())
+                        .setConsumerId(serviceRequestDTO.consumerId())
+                        .setServiceAddress(serviceRequestDTO.serviceAddress())
+                        .setAddressType(serviceRequestDTO.addressType() != null ? serviceRequestDTO.addressType() : "")
+                        .setPreferredStartTime(serviceRequestDTO.preferredStartTime())
+                        .setPreferredEndTime(serviceRequestDTO.preferredEndTime())
+                        .setDuration(serviceRequestDTO.duration())
+                        .setServiceType(serviceRequestDTO.serviceType())
+                        .setRequestStatus(ServiceRequestStatus.ASSIGNED.toString())
+                        .setRequestDate(serviceRequestDTO.requestDate())
+                        .setAdditionalInformation(serviceRequestDTO.additionalInformation() != null ? serviceRequestDTO.additionalInformation() : "")
+                        .setLocation(MatchingServiceOuterClass.Location.newBuilder()
+                                .setLatitude(serviceRequestDTO.location().get(0))
+                                .setLongitude(serviceRequestDTO.location().get(1))
+                                .build())
+                        .build();
+
+        // CaregiverDTO → CaregiverForMatching 변환
+        List<MatchingServiceOuterClass.CaregiverForMatching> protoCaregivers = caregivers.stream()
+                .map(c -> MatchingServiceOuterClass.CaregiverForMatching.newBuilder()
+                        .setCaregiverId(c.caregiverId())
+                        .setUserId(c.userId())
+                        .setName(c.name())
+                        .setAddress(c.address() != null ? c.address() : "")
+                        .setAddressType(c.addressType() != null ? c.addressType() : "")
+                        .setServiceType(c.preferences().getServiceTypes() != null ? c.preferences().getServiceTypes().toString() : "")
+                        .setCareer(c.career() != null ? c.career() : "")
+                        .setKoreanProficiency(c.koreanProficiency() != null ? c.koreanProficiency() : "")
+                        .setIsAccompanyOuting(c.isAccompanyOuting())
+                        .setSelfIntroduction(c.selfIntroduction() != null ? c.selfIntroduction() : "")
+                        .setVerifiedStatus(c.verifiedStatus() != null ? c.verifiedStatus() : "")
+                        .build())
+                .toList();
+
+        return MatchingServiceOuterClass.MatchingRequest.newBuilder()
+                .setServiceRequest(serviceRequest)
+                .addAllCandidateCaregivers(protoCaregivers)
+                .build();
+    }
+
+    public static MatchingResponseDTO toDto(MatchingServiceOuterClass.MatchingResponse response) {
+        if (response == null) {
+            return null;
+        }
+
+        List<MatchedCaregiverDTO> matchedCaregivers = response.getMatchedCaregiversList().stream()
+                .map(c -> new MatchedCaregiverDTO(
+                        c.getCaregiverId(),
+                        c.getName(),
+                        c.getDistanceKm(),
+                        c.getEstimatedTravelTime(),
+                        c.getMatchScore(),
+                        c.getAddress(),
+                        c.getAddressType(),
+                        List.of(c.getLocation().getLatitude(), c.getLocation().getLongitude())
+                                .stream().map(Object::toString).collect(Collectors.toList()),
+                        c.getCareer(),
+                        c.getSelfIntroduction()
+                ))
+                .collect(Collectors.toList());
+
+        return new MatchingResponseDTO(
+                "", // serviceRequestId는 필요하면 별도로 매핑
+                matchedCaregivers,
+                matchedCaregivers.size(),
+                response.getTotalMatches()
+        );
+    }
+
+     */
 }

--- a/homecare/src/main/java/jaega/homecare/domain/serviceMatch/service/command/ServiceMatchCommandService.java
+++ b/homecare/src/main/java/jaega/homecare/domain/serviceMatch/service/command/ServiceMatchCommandService.java
@@ -48,4 +48,9 @@ public class ServiceMatchCommandService {
 
         return serviceMatch.getServiceMatchId();
     }
+
+    public void rejectMatchStatus(ServiceMatch serviceMatch){
+        serviceMatch.changeMatchStatus(MatchStatus.CANCELLED);
+        serviceMatch.getServiceRequest().changeRequestStatus(ServiceRequestStatus.CANCELED);
+    }
 }

--- a/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
+++ b/homecare/src/main/java/jaega/homecare/global/dummy/service/DummyDataService.java
@@ -520,14 +520,16 @@ public class DummyDataService {
                 } else {
                     serviceMatch.changeMatchStatus(MatchStatus.COMPLETED);
 
-                    // COMPLETED이면 리뷰 생성
-                    Review review = Review.builder()
-                            .reviewId(UUID.randomUUID())
-                            .serviceMatch(serviceMatch)
-                            .reviewScore(5.0)
-                            .reviewContent("테스트용 리뷰")
-                            .build();
-                    reviewRepository.save(review);
+                    if (random.nextBoolean()) {
+                        // COMPLETED이면 리뷰 생성
+                        Review review = Review.builder()
+                                .reviewId(UUID.randomUUID())
+                                .serviceMatch(serviceMatch)
+                                .reviewScore(5.0)
+                                .reviewContent("테스트용 리뷰")
+                                .build();
+                        reviewRepository.save(review);
+                    }
                 }
 
                 // ServiceRequest 상태 동기화


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #59 

## 📝작업 내용

> 요양보호사 관련 일정 거절 및 서비스 신청 관련 api를 구현했습니다.
> 매칭 연동을 위해 로직을 임시로 추가했습니다.
### 1. 요양보호사 관련 일정 거절 api를 구현했습니다.

### 2. 매칭 연동을 위해 임시 연동 api를 구현했습니다.

### 스크린샷 (선택)

<br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
